### PR TITLE
Added footprints for PDIP (plastic dual inline package)

### DIFF
--- a/packages/ic/th/dip/direct_solder/DIP10_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP10_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,642 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -6562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                6250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                5500000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                6562500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                6250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                6250000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                6562500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                5500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                5500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -6562500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP10, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 12.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -6500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    7562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b8e038ba-6758-4e3c-89ce-e3736c59c800"
+}

--- a/packages/ic/th/dip/direct_solder/DIP12_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP12_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,674 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -7812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                7500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                6750000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                7812500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                7500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                7500000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                7812500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                6750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                6750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -7812500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP12, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 15.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -7750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    8812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -6250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "fac30cae-4907-4aaa-9b24-cd3441958bde"
+}

--- a/packages/ic/th/dip/direct_solder/DIP14_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP14_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,706 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -9062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                8750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                8000000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                9062500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                8750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                8750000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                9062500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                8000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                8000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -9062500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP14, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 17.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -9000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    10062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -7500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "07e2d21f-ce33-4c58-9d56-6b2dce0e6919"
+}

--- a/packages/ic/th/dip/direct_solder/DIP16_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP16_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,738 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -10312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                10000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                9250000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                10312500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                10000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                10000000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                10312500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                9250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                9250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -10312500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP16, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 20.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -10250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    11312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "374572a8-8482-44cb-bfcb-168cabcaae69"
+}

--- a/packages/ic/th/dip/direct_solder/DIP18_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP18_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,770 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -11562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                11250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                10500000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                11562500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                11250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                11250000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                11562500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                10500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                10500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -11562500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP18, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 22.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -11500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    12562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "2cf1b1cb-e924-4408-9cd2-85d92ebd23ac"
+}

--- a/packages/ic/th/dip/direct_solder/DIP20_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP20_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,802 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -12812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                12500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                11750000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                12812500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                12500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                12500000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                12812500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                11750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                11750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -12812500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP20, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 25.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -12750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    13812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -11250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "49c8d995-614f-45ce-8839-248f5c7f09b8"
+}

--- a/packages/ic/th/dip/direct_solder/DIP22_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP22_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,834 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -14062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                13750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                13000000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                14062500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                13750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                13750000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                14062500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                13000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                13000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -14062500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP22, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 27.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -14000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    15062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -12500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "177c7e9a-b1e6-4d56-9528-c1b3cabc0ce5"
+}

--- a/packages/ic/th/dip/direct_solder/DIP24_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP24_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,866 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -15312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                15000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                14250000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                15312500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                15000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                15000000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                15312500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                14250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                14250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -15312500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP24, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7e086e91-60ba-4fc0-ac1a-1c8c0cab776e": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "d1d7f91d-5569-4fb5-a0d8-1bf15d1d7e34": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 30.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -15250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    16312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "76cf0725-4925-4491-9dcf-4f44c769f174"
+}

--- a/packages/ic/th/dip/direct_solder/DIP26_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP26_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,898 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": false
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -16562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                16250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                15500000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                16562500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                16250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                16250000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                16562500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                15500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                15500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -16562500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP26, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "2b7f606c-deeb-48ab-bc61-a8f8ab22a2c5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "7e086e91-60ba-4fc0-ac1a-1c8c0cab776e": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "87b7b5d4-c64e-4353-99eb-026e0d56e261": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "d1d7f91d-5569-4fb5-a0d8-1bf15d1d7e34": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 32.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -16500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    17562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "331c8b00-860e-4c35-b2c1-b81fa82094a3"
+}

--- a/packages/ic/th/dip/direct_solder/DIP28_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP28_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,930 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -17812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                17500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                16750000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                17812500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                17500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                17500000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                17812500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                16750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                16750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -17812500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP28, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "2b7f606c-deeb-48ab-bc61-a8f8ab22a2c5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "2cd58196-9fc6-4ff8-8211-9ae5230d8719": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "7e086e91-60ba-4fc0-ac1a-1c8c0cab776e": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "87b7b5d4-c64e-4353-99eb-026e0d56e261": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "aea27a9c-12ce-4d0b-aff1-f7e539623d49": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "d1d7f91d-5569-4fb5-a0d8-1bf15d1d7e34": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 35.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -17750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    18812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -16250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "24ac24db-005c-4041-95da-542aa25ee424"
+}

--- a/packages/ic/th/dip/direct_solder/DIP30_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP30_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,962 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -19062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                18750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                18000000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                19062500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                18750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                18750000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                19062500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                18000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -19062500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP30, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -17500000
+                ]
+            }
+        },
+        "2b7f606c-deeb-48ab-bc61-a8f8ab22a2c5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "2cd58196-9fc6-4ff8-8211-9ae5230d8719": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "51066ced-a549-48b3-8865-e4b664c2a46a": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "6924bad7-9562-4f22-b2a1-56881d6e408c": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    17500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "7e086e91-60ba-4fc0-ac1a-1c8c0cab776e": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    17500000
+                ]
+            }
+        },
+        "87b7b5d4-c64e-4353-99eb-026e0d56e261": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "aea27a9c-12ce-4d0b-aff1-f7e539623d49": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "d1d7f91d-5569-4fb5-a0d8-1bf15d1d7e34": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -17500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 37.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -19000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    20062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -17500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "9430c6c2-dcac-4f85-920a-9748fb995ed2"
+}

--- a/packages/ic/th/dip/direct_solder/DIP32_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP32_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,994 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -20312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                20000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                19250000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                20312500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                20000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                20000000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                20312500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                19250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                19250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -20312500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP32, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "047ab7ff-1537-43f2-909c-55617286d357": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "28cce48d-872f-421d-b71b-523b2e19661d": {
+            "name": "31",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "2b7f606c-deeb-48ab-bc61-a8f8ab22a2c5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "2cd58196-9fc6-4ff8-8211-9ae5230d8719": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "51066ced-a549-48b3-8865-e4b664c2a46a": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "6924bad7-9562-4f22-b2a1-56881d6e408c": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "78ded803-ce28-4fa9-b40e-1a1595e20602": {
+            "name": "32",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    18750000
+                ]
+            }
+        },
+        "7e086e91-60ba-4fc0-ac1a-1c8c0cab776e": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    18750000
+                ]
+            }
+        },
+        "87b7b5d4-c64e-4353-99eb-026e0d56e261": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "8a4877b4-a4b6-4c33-b0cc-1f76ebc00a3c": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -18750000
+                ]
+            }
+        },
+        "ae1a2a4e-e4c6-4e56-be0c-fdb6aec9000d": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "aea27a9c-12ce-4d0b-aff1-f7e539623d49": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "be7d7107-00b7-4d96-a53e-a4f62be0b26b": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "d1d7f91d-5569-4fb5-a0d8-1bf15d1d7e34": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -18750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 40.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -20250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    21312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -18750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "917b713f-6d55-46b8-b448-16f0808f2456"
+}

--- a/packages/ic/th/dip/direct_solder/DIP6_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP6_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,578 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -4062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                3750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                3000000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                4062500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                3750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                3750000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                4062500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                3000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                3000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -4062500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP6, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 7.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -4000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    5062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "e887a48c-a085-4ae6-aa85-a06ea15064bc"
+}

--- a/packages/ic/th/dip/direct_solder/DIP8_7.62mm_lead_span_2.54mm_pitch/package.json
+++ b/packages/ic/th/dip/direct_solder/DIP8_7.62mm_lead_span_2.54mm_pitch/package.json
@@ -1,0 +1,610 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.899999976158142,
+                        "g": 0.899999976158142,
+                        "r": 0.899999976158142
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "hatch",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.899999976158142,
+                        "g": 0.899999976158142,
+                        "r": 0.899999976158142
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "hatch",
+                    "visible": false
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -5312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                5000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                4250000
+            ]
+        },
+        "5121192d-a25e-4e60-b4bc-4a8187f22fa7": {
+            "position": [
+                -4375000,
+                5312500
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                5000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                5000000
+            ]
+        },
+        "83727558-eda1-4a2e-88f7-e711ed0c3d05": {
+            "position": [
+                2750000,
+                5312500
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                4250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                4250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -5312500
+            ]
+        }
+    },
+    "lines": {
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        },
+        "d79784c5-a09b-43d1-af54-582ae4dc424f": {
+            "from": "5121192d-a25e-4e60-b4bc-4a8187f22fa7",
+            "layer": 20,
+            "to": "83727558-eda1-4a2e-88f7-e711ed0c3d05",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP8, 7.62 mm lead span 2.54 mm pitch",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 10.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -5250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4437500,
+                    6312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "d39137d0-f433-40ab-872c-263c701420b0"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP10_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP10_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,668 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "b8e038ba-6758-4e3c-89ce-e3736c59c800",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                6250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                5500000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -6250000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -6250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                6250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                6250000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                6250000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                6250000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                6250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                5500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                5500000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP10, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 12.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -6500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "0a99326e-c874-4090-b280-a70f30d08b23"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP12_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP12_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,706 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "fac30cae-4907-4aaa-9b24-cd3441958bde",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                7500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                6750000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -7500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                6750000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -7500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                7500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                7500000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                7500000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                7500000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                7500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                6750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                6750000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP12, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 15.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -7750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -6312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -6250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "17c5dab9-ced4-49d9-be16-686871ec033f"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP14_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP14_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,738 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "07e2d21f-ce33-4c58-9d56-6b2dce0e6919",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                8750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                8000000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -8750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                8000000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -8750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                8750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                8750000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                8750000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                8750000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                8750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                8000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                8000000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP14, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 17.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -9000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -7562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -7500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "35bb66a9-5de9-45b1-9825-dc487cd3956e"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP16_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP16_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,770 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "374572a8-8482-44cb-bfcb-168cabcaae69",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                10000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                9250000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -10000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                9250000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -10000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                10000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                10000000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                10000000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                10000000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                10000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                9250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                9250000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP16, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 20.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -10250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b77d00fe-d61d-43eb-ac6d-fa6bd1bdb576"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP18_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP18_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,802 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "2cf1b1cb-e924-4408-9cd2-85d92ebd23ac",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                11250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                10500000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -11250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                10500000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -11250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                11250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                11250000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                11250000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                11250000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                11250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                10500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                10500000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP18, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 22.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -11500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "ca6cf1fc-d425-4053-bc27-6208166a4e1d"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP20_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP20_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,834 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "49c8d995-614f-45ce-8839-248f5c7f09b8",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                12500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                11750000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -12500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                11750000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -12500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                12500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                12500000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                12500000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                12500000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                12500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                11750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                11750000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP20, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 25.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -12750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -11312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -11250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "231dbedd-0f57-481e-bbae-b1846b1ffaa3"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP22_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP22_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,866 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "177c7e9a-b1e6-4d56-9528-c1b3cabc0ce5",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                13750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                13000000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -13750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                13000000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -13750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                13750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                13750000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                13750000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                13750000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                13750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                13000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                13000000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP22, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 27.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -14000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -12562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -12500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "2343cd95-3080-4f73-bb28-08adaae01339"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP24_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP24_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,898 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "76cf0725-4925-4491-9dcf-4f44c769f174",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                15000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                14250000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -15000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                14250000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -15000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                15000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                15000000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                15000000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                15000000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                15000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                14250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                14250000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP24, 7.62 mm lead span 2.54 mm pitch (DIY Silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "5bddda4c-fbc2-4d9a-a6bb-8481929a3ab4": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "910a4f36-72bb-4cef-a48a-ff0b55c49831": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 30.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -15250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "4f879c61-c9d0-4fc9-896d-5146b9531c66"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP26_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP26_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,930 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "331c8b00-860e-4c35-b2c1-b81fa82094a3",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                16250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                15500000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -16250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                15500000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -16250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                16250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                16250000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                16250000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                16250000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                16250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                15500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                15500000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP26, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "5bddda4c-fbc2-4d9a-a6bb-8481929a3ab4": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "66ed2d5d-344c-4257-b581-f68f4c0919b0": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "833dee70-5109-4059-b46f-9aefbb902875": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "910a4f36-72bb-4cef-a48a-ff0b55c49831": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 32.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -16500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "578e1a20-734e-4713-b4e0-d449376e396d"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP28_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP28_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,962 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "24ac24db-005c-4041-95da-542aa25ee424",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                17500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                16750000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -17500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                16750000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -17500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                17500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                17500000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                17500000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                17500000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                17500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                16750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                16750000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP28, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "5bddda4c-fbc2-4d9a-a6bb-8481929a3ab4": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "66ed2d5d-344c-4257-b581-f68f4c0919b0": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "833dee70-5109-4059-b46f-9aefbb902875": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "8894fc2f-6bb9-4b0d-b736-f429ae78fd8c": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "910a4f36-72bb-4cef-a48a-ff0b55c49831": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "940320aa-af72-4803-b9fc-a5ffa64bbea0": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 35.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -17750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -16312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -16250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "f215eb85-c95d-4b0d-b1dd-5fffb5586e15"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP30_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP30_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,994 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "9430c6c2-dcac-4f85-920a-9748fb995ed2",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                18750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                18000000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -18750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -18750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                18750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                18750000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                18750000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                18750000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                18750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                18000000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP30, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -17500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "5bddda4c-fbc2-4d9a-a6bb-8481929a3ab4": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "66ed2d5d-344c-4257-b581-f68f4c0919b0": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "7e6cf1e6-16b5-47e2-bc7e-52d9ce94985f": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    17500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    17500000
+                ]
+            }
+        },
+        "833dee70-5109-4059-b46f-9aefbb902875": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "8894fc2f-6bb9-4b0d-b736-f429ae78fd8c": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "910a4f36-72bb-4cef-a48a-ff0b55c49831": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "940320aa-af72-4803-b9fc-a5ffa64bbea0": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -17500000
+                ]
+            }
+        },
+        "eaf16c7b-0838-4f50-b20b-ec0670b88828": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 37.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -19000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -17562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -17500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "fbe95d8a-6588-4017-836f-8aea367ef004"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP32_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP32_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,1026 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "917b713f-6d55-46b8-b448-16f0808f2456",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                20000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                19250000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -20000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                19250000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -20000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                20000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                20000000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                20000000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                20000000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                20000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                19250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                19250000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP32, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "02f6dfe2-bf6a-4555-b032-807f2075484c": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "06d58ddf-bf84-49d0-8109-4b50bc871199": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "1670a208-28aa-4edb-a925-0303c5c7c8c7": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -18750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "29590751-3f70-4245-9541-14d63878daa2": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "3783a7f8-1eb6-466e-b108-c2fdf366f54c": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -18750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "4da7fe66-0d45-4e3e-9604-a0ee94b297e2": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "5bddda4c-fbc2-4d9a-a6bb-8481929a3ab4": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "66ed2d5d-344c-4257-b581-f68f4c0919b0": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "70a36bdd-91a7-4da1-9921-c408e3d433cd": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "7e6cf1e6-16b5-47e2-bc7e-52d9ce94985f": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    18750000
+                ]
+            }
+        },
+        "833dee70-5109-4059-b46f-9aefbb902875": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "8894fc2f-6bb9-4b0d-b736-f429ae78fd8c": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "8b1b8a82-c8e2-48d4-91a9-87d5547ef665": {
+            "name": "32",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    18750000
+                ]
+            }
+        },
+        "8d360333-08b7-4eb7-966f-91736700bd89": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "910a4f36-72bb-4cef-a48a-ff0b55c49831": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "92d7f6b6-4e6a-4e03-b93a-77992129dfb7": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "940320aa-af72-4803-b9fc-a5ffa64bbea0": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "9765022f-f8a2-412c-ac18-608b4dd2ee05": {
+            "name": "31",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "d71d6cfd-0da8-4552-82d5-f0a7200aa069": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "dfc56679-8415-4300-a0c9-8a757deec00d": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "e78c410b-4ae6-4bc0-8ecd-ff064a0e486e": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "eaf16c7b-0838-4f50-b20b-ec0670b88828": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "fb1e1272-51ee-4d73-be80-05b72a2fccf2": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "ff36baf5-51c7-4786-9e2f-ce2d30bdf59f": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 40.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -20250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -18812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -18750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "bcd4a021-50cd-47c5-aba1-11f4a8535d0e"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP6_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP6_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,610 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "e887a48c-a085-4ae6-aa85-a06ea15064bc",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                3750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                3000000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -3750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                3000000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -3750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                3750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                3750000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                3750000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                3750000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                3750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                3000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                3000000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP6, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 7.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -4000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "7f112a30-8add-4652-a84e-5bb92d4a7d94"
+}

--- a/packages/ic/th/dip/direct_solder_diy/DIP8_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/direct_solder_diy/DIP8_7.62mm_lead_span_2.54mm_pitch_(diy_silkscreen)/package.json
@@ -1,0 +1,642 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": false
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "d39137d0-f433-40ab-872c-263c701420b0",
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c0215d68-c359-4dfc-855c-0f863eb0c40f": {
+            "center": "984c1351-e497-4cb2-be4a-38143242a2db",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                5000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                4250000
+            ]
+        },
+        "383e4193-204d-411f-906a-23cee2158def": {
+            "position": [
+                -2750000,
+                -5000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                4250000
+            ]
+        },
+        "5c09e05c-c01f-415a-8664-0cdd9986af2e": {
+            "position": [
+                2750000,
+                -5000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                5000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                5000000
+            ]
+        },
+        "89fdac67-8992-4927-88ee-00bcc65043bb": {
+            "position": [
+                2750000,
+                5000000
+            ]
+        },
+        "984c1351-e497-4cb2-be4a-38143242a2db": {
+            "position": [
+                0,
+                5000000
+            ]
+        },
+        "b471af7e-c6c0-432c-81bc-c0e9793c40eb": {
+            "position": [
+                -2750000,
+                5000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                4250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                4250000
+            ]
+        }
+    },
+    "lines": {
+        "a65c58a7-ff95-4884-8c1c-f762cb83abc0": {
+            "from": "383e4193-204d-411f-906a-23cee2158def",
+            "layer": 20,
+            "to": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "width": 150000
+        },
+        "ace3ead9-d84c-4f93-8eee-46b81f71aee3": {
+            "from": "b471af7e-c6c0-432c-81bc-c0e9793c40eb",
+            "layer": 20,
+            "to": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "width": 150000
+        },
+        "b3a12288-2056-4e22-8d9f-2da9f516f8cb": {
+            "from": "89fdac67-8992-4927-88ee-00bcc65043bb",
+            "layer": 20,
+            "to": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "width": 150000
+        },
+        "db279776-4c1f-418f-be3f-7e5ff75fc69b": {
+            "from": "5c09e05c-c01f-415a-8664-0cdd9986af2e",
+            "layer": 20,
+            "to": "383e4193-204d-411f-906a-23cee2158def",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP8, 7.62 mm lead span 2.54 mm pitch (DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "8.850mm 10.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "158d4299-1a3f-4318-9659-ac05764a9466": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        -5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4675000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4675000,
+                        -5250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "968b638e-a4a2-4081-800b-b05efd1e609d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        0,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2750000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2750000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3449999,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        949999,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3449999,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        950000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "59e74877-e7ef-4517-98f6-e921387719a1"
+}

--- a/packages/ic/th/dip/with_socket/DIP10_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP10_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,673 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -6562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                6250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                5500000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                6500000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                6500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                6250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                6250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                5500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                5500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -6562500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP10, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 12.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -6500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    7562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "d97dc6fe-6a77-4cd7-a6ae-555ea9c3735a"
+}

--- a/packages/ic/th/dip/with_socket/DIP12_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP12_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,705 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -7812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                7500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                6750000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                7750000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                7750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                7500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                7500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                6750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                6750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -7812500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP12, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 15.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -7750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    8812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -6250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "211069a0-f144-4d11-a223-517af4048bf8"
+}

--- a/packages/ic/th/dip/with_socket/DIP14_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP14_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,737 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -9062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                8750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                8000000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                9000000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                9000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                8750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                8750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                8000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                8000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -9062500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP14, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 17.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -9000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    10062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -7500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "990fd5f3-9a75-4fd8-964d-cdff7785ad93"
+}

--- a/packages/ic/th/dip/with_socket/DIP16_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP16_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,769 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -10312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                10000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                9250000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                10250000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                10250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                10000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                10000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                9250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                9250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -10312500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP16, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 20.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -10250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    11312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "d7c13c30-b60b-453f-b1f2-b4a63bf13217"
+}

--- a/packages/ic/th/dip/with_socket/DIP18_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP18_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,801 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -11562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                11250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                10500000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                11500000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                11500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                11250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                11250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                10500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                10500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -11562500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP18, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 22.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -11500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    12562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "368eb0f5-ef8e-48c2-9833-0f4b46729eb1"
+}

--- a/packages/ic/th/dip/with_socket/DIP20_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP20_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,833 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -12812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                12500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                11750000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                12750000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                12750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                12500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                12500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                11750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                11750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -12812500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP20, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 25.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -12750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    13812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -11250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b6b007b0-baec-407f-a2e0-1e8ec51e5267"
+}

--- a/packages/ic/th/dip/with_socket/DIP22_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP22_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,865 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -14062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                13750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                13000000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                14000000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                14000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                13750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                13750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                13000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                13000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -14062500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP22, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 27.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -14000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    15062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -12500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "5b9df941-3b7a-4597-a876-34c60a5156b8"
+}

--- a/packages/ic/th/dip/with_socket/DIP24_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP24_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,897 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -15312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                15000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                14250000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                15250000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                15250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                15000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                15000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                14250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                14250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -15312500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP24, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "0465251a-e67a-4f39-a8d4-faf5fc46cc97": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "db75624f-54ae-4008-9610-baca1fd9ddfb": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 30.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -15250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    16312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "3f010af2-c572-4ce9-b6d8-cd96364193a9"
+}

--- a/packages/ic/th/dip/with_socket/DIP26_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP26_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,929 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -16562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                16250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                15500000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                16500000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                16500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                16250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                16250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                15500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                15500000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -16562500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP26, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "0465251a-e67a-4f39-a8d4-faf5fc46cc97": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "9ee246d7-a6ba-4014-9d32-568ee76591f5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "db75624f-54ae-4008-9610-baca1fd9ddfb": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "e4c12300-9347-4be9-ba50-de658cd14158": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 32.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -16500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    17562500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "06276a22-c1e7-41ca-ac9d-e68feba4da9b"
+}

--- a/packages/ic/th/dip/with_socket/DIP28_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP28_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,961 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -17812500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                17500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                16750000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                17750000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                17750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                17500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                17500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                16750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                16750000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -17812500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP28, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "0465251a-e67a-4f39-a8d4-faf5fc46cc97": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "9ee246d7-a6ba-4014-9d32-568ee76591f5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "ca2f527a-ad5c-4eeb-adfd-3c2c76f9d73d": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "db75624f-54ae-4008-9610-baca1fd9ddfb": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "e4c12300-9347-4be9-ba50-de658cd14158": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "fdb75ba4-3811-466c-9ff4-9fc230b23a04": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 35.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -17750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    18812500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -16250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b8cb1f6a-a723-41f3-bd40-c32fb0383d42"
+}

--- a/packages/ic/th/dip/with_socket/DIP30_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP30_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,993 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -19062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                18750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                18000000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                19000000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                19000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                18750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                18750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                18000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -19062500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP30, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "0465251a-e67a-4f39-a8d4-faf5fc46cc97": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "388dda03-0e8b-4aa2-b86d-6e38585f6557": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    17500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -17500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    17500000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "9ee246d7-a6ba-4014-9d32-568ee76591f5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -17500000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "c3dffe10-efab-4ab2-950a-7e51fe8b3e91": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "ca2f527a-ad5c-4eeb-adfd-3c2c76f9d73d": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "db75624f-54ae-4008-9610-baca1fd9ddfb": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "e4c12300-9347-4be9-ba50-de658cd14158": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "fdb75ba4-3811-466c-9ff4-9fc230b23a04": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 37.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -19000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    20062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -17500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "588aac08-29d4-47f4-ac36-143605330621"
+}

--- a/packages/ic/th/dip/with_socket/DIP32_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP32_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,1025 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -21562500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                18750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                18000000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                19000000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                19000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                18750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                18750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                18000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -21562500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP32, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "0465251a-e67a-4f39-a8d4-faf5fc46cc97": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "388dda03-0e8b-4aa2-b86d-6e38585f6557": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "5f58c455-e4f6-4234-89e5-c31ac92fba30": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -20000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    17500000
+                ]
+            }
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "9ee246d7-a6ba-4014-9d32-568ee76591f5": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "a2c58420-58ae-49e0-afc2-23587738ef98": {
+            "name": "31",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -17500000
+                ]
+            }
+        },
+        "b90389d6-29c7-4178-9968-c75e6e45b6a9": {
+            "name": "32",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    17500000
+                ]
+            }
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -17500000
+                ]
+            }
+        },
+        "c3dffe10-efab-4ab2-950a-7e51fe8b3e91": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "ca2f527a-ad5c-4eeb-adfd-3c2c76f9d73d": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "ce827efd-443a-4b86-8ed9-d3db112d5f1d": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "db75624f-54ae-4008-9610-baca1fd9ddfb": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "e2fae7da-e1c4-4acf-abfd-7113417e40a9": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "e4c12300-9347-4be9-ba50-de658cd14158": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "f9d73206-df04-4f25-820c-af0732434835": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -20000000
+                ]
+            }
+        },
+        "fdb75ba4-3811-466c-9ff4-9fc230b23a04": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 40.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm -1.250mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -21250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -21250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -21250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -21250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -21250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -21250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -21500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -21500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    20062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -20000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "03052e0f-926a-4ac4-a95c-7ecf81d1e304"
+}

--- a/packages/ic/th/dip/with_socket/DIP6_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP6_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,609 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -4062500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                3750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                3000000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                4000000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                4000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                3750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                3750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                3000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                3000000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -4062500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP6, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 7.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -4000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    5062500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "24c56240-d530-4fd8-a4b4-0bb175513b05"
+}

--- a/packages/ic/th/dip/with_socket/DIP8_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
+++ b/packages/ic/th/dip/with_socket/DIP8_7.62mm_lead_span_2.54mm_pitch_(with_socket)/package.json
@@ -1,0 +1,641 @@
+{
+    "_imp": {
+        "grid_spacing": 1250000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb": {
+            "position": [
+                -2750000,
+                -5312500
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                5000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                4250000
+            ]
+        },
+        "35987ba0-bfd1-4d94-8238-16a6352e9261": {
+            "position": [
+                2500000,
+                5250000
+            ]
+        },
+        "43cc1e00-6de2-4cd0-9fbc-80397505e291": {
+            "position": [
+                -5000000,
+                5250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -937500,
+                5000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                937500,
+                5000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                4250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                4250000
+            ]
+        },
+        "dfdc471a-3e51-4cde-a162-edcbd817d8ae": {
+            "position": [
+                2750000,
+                -5312500
+            ]
+        }
+    },
+    "lines": {
+        "103cee99-aa32-4113-ac67-23d3674cd15c": {
+            "from": "43cc1e00-6de2-4cd0-9fbc-80397505e291",
+            "layer": 20,
+            "to": "35987ba0-bfd1-4d94-8238-16a6352e9261",
+            "width": 150000
+        },
+        "d3b2d073-6051-4810-9ddd-7fed1179060b": {
+            "from": "08b51e3f-ac8b-48e6-9b13-4eae8294c9fb",
+            "layer": 20,
+            "to": "dfdc471a-3e51-4cde-a162-edcbd817d8ae",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP8, 7.62 mm lead span 2.54 mm pitch (with socket)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 10.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -5250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5062500,
+                    6312500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b55fec84-cbdb-40a8-a7a1-776b0d7520c2"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP10_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP10_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,705 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "d97dc6fe-6a77-4cd7-a6ae-555ea9c3735a",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -6250000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                -62500,
+                6250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                5500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                5497500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                6250000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                -62500,
+                6250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -1000000,
+                6250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                875000,
+                6250000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                6250000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -6250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                5500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                5500000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP10, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 12.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -6250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        6500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -6500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5687500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "3c013f20-3431-424a-9ed6-73948a3345d4"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP12_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP12_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,737 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "211069a0-f144-4d11-a223-517af4048bf8",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -7500000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                7500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                6750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                6747500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                7500000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                7500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                7500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                7500000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                7500000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -7500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                6750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                6750000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP12, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 15.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        7500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -7500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        7750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -7750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -6937500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -7000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "87e1906e-ae05-4d69-90d8-125dd02e8003"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP14_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP14_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,769 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "990fd5f3-9a75-4fd8-964d-cdff7785ad93",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -8750000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                8750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                8000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                7997500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                8750000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                8750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                8750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                8750000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                8750000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -8750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                8000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                8000000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP14, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 17.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        8750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -8750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        9000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -9000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8187500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -8250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "a1e51b00-34b6-493a-9cdb-bc195d99335c"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP16_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP16_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,801 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "d7c13c30-b60b-453f-b1f2-b4a63bf13217",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -10000000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                10000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                9250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                9247500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                10000000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                10000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                10000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                10000000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                10000000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -10000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                9250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                9250000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP16, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 20.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        10000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -10000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        10250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -10250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -9437500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -9500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "be5e2a41-ce07-4609-978a-5a8be9f3dfc3"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP18_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP18_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,833 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "368eb0f5-ef8e-48c2-9833-0f4b46729eb1",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -11250000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                11250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                10500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                10497500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                11250000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                11250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                11250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                11250000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                11250000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -11250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                10500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                10500000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP18, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 22.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        11250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -11250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        11500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -11500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10687500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -10750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "20b7bff3-2177-4e7c-aa8f-1372fda36348"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP20_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP20_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,865 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "b6b007b0-baec-407f-a2e0-1e8ec51e5267",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -12500000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                12500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                11750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                11747500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                12500000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                12500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                12500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                12500000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                12500000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -12500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                11750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                11750000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP20, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 25.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        12500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -12500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        12750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -12750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -11937500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -12000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "6d1f5ea1-fd0b-4420-8e90-f378f5aef1b7"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP22_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP22_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,897 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "5b9df941-3b7a-4597-a876-34c60a5156b8",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -13750000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                13750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                13000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                12997500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                13750000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                13750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                13750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                13750000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                13750000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -13750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                13000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                13000000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP22, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 27.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        13750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -13750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        14000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -14000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13187500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -13250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "c1dde78f-1774-4aab-a028-c312e344879d"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP24_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP24_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,929 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "3f010af2-c572-4ce9-b6d8-cd96364193a9",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -15000000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                15000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                14250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                14247500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                15000000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                15000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                15000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                15000000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                15000000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -15000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                14250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                14250000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP24, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "8143d66b-f56a-4f50-b9f0-646e11df9b39": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "c2aaa961-f3e9-41b3-b459-430cf3cf9a70": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 30.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        15000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -15000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        15250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -15250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -14437500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -14500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "d3aa31f0-332a-41fd-b2c8-f091ab903ed0"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP26_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP26_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,961 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "06276a22-c1e7-41ca-ac9d-e68feba4da9b",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -16250000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                16250000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                15500000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                15497500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                16250000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                16250000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                16250000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                16250000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                16250000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -16250000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                15500000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                15500000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP26, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "8143d66b-f56a-4f50-b9f0-646e11df9b39": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "c2aaa961-f3e9-41b3-b459-430cf3cf9a70": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "f505e0da-ea89-476a-9c39-3bcc1865a486": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "f61d60ad-b390-4384-aa91-1cf973402e91": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 32.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        16250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -16250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        16500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -16500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15687500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -15750000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "f082f4ff-8efc-4d74-9e50-3a83a1e053e1"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP28_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP28_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,993 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "b8cb1f6a-a723-41f3-bd40-c32fb0383d42",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -17500000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                17500000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                16750000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                16747500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                17500000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                17500000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                17500000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                17500000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                17500000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -17500000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                16750000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                16750000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP28, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "18d65d86-8cb0-46c8-97fe-0f51ebcc0e67": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "8143d66b-f56a-4f50-b9f0-646e11df9b39": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "c2aaa961-f3e9-41b3-b459-430cf3cf9a70": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "f37c8ed6-47cd-4197-8400-7e0550f1aa91": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "f505e0da-ea89-476a-9c39-3bcc1865a486": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "f61d60ad-b390-4384-aa91-1cf973402e91": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 35.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        17500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -17500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        17750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -17750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -16937500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -17000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "50a23b5b-6495-4e95-9e7d-69bd63ecdd06"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP30_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP30_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,1025 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "588aac08-29d4-47f4-ac36-143605330621",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -18750000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                18750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                18000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                17997500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                18750000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                18750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                18750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                18750000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                18750000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -18750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                18000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                18000000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP30, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    5000000
+                ]
+            }
+        },
+        "18d65d86-8cb0-46c8-97fe-0f51ebcc0e67": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    10000000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -15000000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    15000000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -17500000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    7500000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -5000000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -7500000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "6b77c936-1963-4ec2-aa01-ff622880dbc4": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    17500000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -15000000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    10000000
+                ]
+            }
+        },
+        "8143d66b-f56a-4f50-b9f0-646e11df9b39": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    17500000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -17500000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -10000000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -7500000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -10000000
+                ]
+            }
+        },
+        "c2aaa961-f3e9-41b3-b459-430cf3cf9a70": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -5000000
+                ]
+            }
+        },
+        "d4bb54e6-4998-48d8-bbbb-ab6f7221dc42": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    15000000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -12500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    12500000
+                ]
+            }
+        },
+        "f37c8ed6-47cd-4197-8400-7e0550f1aa91": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    12500000
+                ]
+            }
+        },
+        "f505e0da-ea89-476a-9c39-3bcc1865a486": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    7500000
+                ]
+            }
+        },
+        "f61d60ad-b390-4384-aa91-1cf973402e91": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    5000000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -12500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 37.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        18750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -18750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        19000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -19000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -18187500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -18250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "b23b4ae3-95dd-44a8-8fd5-4516bb1a1489"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP32_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP32_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,1057 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "03052e0f-926a-4ac4-a95c-7ecf81d1e304",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -20000000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                20000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                19250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                19247500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                20000000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                20000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                20000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                20000000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                20000000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -20000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                19250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                19250000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP32, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    6250000
+                ]
+            }
+        },
+        "18d65d86-8cb0-46c8-97fe-0f51ebcc0e67": {
+            "name": "27",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    6250000
+                ]
+            }
+        },
+        "1ba47d0d-397c-4874-af84-df76b7d252c8": {
+            "name": "14",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -13750000
+                ]
+            }
+        },
+        "1e4ee810-e8db-4ca1-a56d-8597dfd8b896": {
+            "name": "22",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -6250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    16250000
+                ]
+            }
+        },
+        "4a531c32-9be6-44b5-84e8-3db50bf5fc8c": {
+            "name": "16",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -18750000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    8750000
+                ]
+            }
+        },
+        "51f0a7f0-e862-4e76-8f42-ec1c1d1b39f3": {
+            "name": "21",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -8750000
+                ]
+            }
+        },
+        "5c2147c6-4e3d-4c44-9740-617c84d6c005": {
+            "name": "20",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -11250000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "6a20ce3e-0983-4471-ad3a-0f8ea58c00e8": {
+            "name": "31",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    16250000
+                ]
+            }
+        },
+        "6b77c936-1963-4ec2-aa01-ff622880dbc4": {
+            "name": "30",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    13750000
+                ]
+            }
+        },
+        "6da15b94-1f3c-4a60-9c78-71d7714f9730": {
+            "name": "17",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -18750000
+                ]
+            }
+        },
+        "70c67cde-2069-4ba0-a25b-1fef9facb614": {
+            "name": "9",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    11250000
+                ]
+            }
+        },
+        "8143d66b-f56a-4f50-b9f0-646e11df9b39": {
+            "name": "23",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    18750000
+                ]
+            }
+        },
+        "91b366e6-76ab-4e40-b9b8-9f05b2ea6057": {
+            "name": "15",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -16250000
+                ]
+            }
+        },
+        "977f69ac-0da7-490e-8961-e7cf3b8d6b48": {
+            "name": "12",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -8750000
+                ]
+            }
+        },
+        "9d6ef102-e9e4-48a5-a7aa-9e2927bc8f15": {
+            "name": "11",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -6250000
+                ]
+            }
+        },
+        "9d7868a7-47d2-4c6b-a060-2cabdc42744e": {
+            "name": "19",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -13750000
+                ]
+            }
+        },
+        "9fd43d7d-8325-4f5c-a9ff-c29d8846e69f": {
+            "name": "32",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    18750000
+                ]
+            }
+        },
+        "c2aaa961-f3e9-41b3-b459-430cf3cf9a70": {
+            "name": "24",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "c88f9af7-1df6-48c8-8782-5865a074f571": {
+            "name": "10",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "d4bb54e6-4998-48d8-bbbb-ab6f7221dc42": {
+            "name": "29",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    11250000
+                ]
+            }
+        },
+        "df023b53-4711-4dd8-8507-d704f8b96ac9": {
+            "name": "13",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -11250000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    13750000
+                ]
+            }
+        },
+        "f37c8ed6-47cd-4197-8400-7e0550f1aa91": {
+            "name": "28",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    8750000
+                ]
+            }
+        },
+        "f505e0da-ea89-476a-9c39-3bcc1865a486": {
+            "name": "26",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "f61d60ad-b390-4384-aa91-1cf973402e91": {
+            "name": "25",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "f9e51931-2b58-4909-9edd-cbf2133890db": {
+            "name": "18",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -16250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 40.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        20000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -20000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        20250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -20250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -19437500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -19500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "01c101e5-3f8c-44a2-85e6-7401c38a887b"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP6_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP6_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,641 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "24c56240-d530-4fd8-a4b4-0bb175513b05",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -3750000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                3750000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                3000000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                2997500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                3750000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                3750000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                3750000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                3750000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                3750000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -3750000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                3000000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                3000000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP6, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    2500000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    0
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -2500000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    2500000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -2500000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 7.500mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        3750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -3750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        4000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -4000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3187500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3250000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "28743286-d363-41bd-ab03-a9a4321d31e2"
+}

--- a/packages/ic/th/dip/with_socket_diy/DIP8_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
+++ b/packages/ic/th/dip/with_socket_diy/DIP8_7.62mm_lead_span_2.54mm_pitch_(with_socket_diy_silkscreen)/package.json
@@ -1,0 +1,673 @@
+{
+    "_imp": {
+        "grid_spacing": 625000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "alternate_for": "b55fec84-cbdb-40a8-a7a1-776b0d7520c2",
+    "arcs": {
+        "14753141-9e4b-4d1c-ae91-0f799572dfaa": {
+            "center": "71230b10-1560-4af4-a436-4bcbfe939ede",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 20,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 150000
+        },
+        "5e68da66-adac-4f22-b191-bdd175bfe209": {
+            "center": "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d",
+            "from": "744b39e0-e6ae-4848-8c6c-3337674dea6f",
+            "layer": 50,
+            "to": "798ae81f-1552-4d05-84c6-cfe3aa7e98b8",
+            "width": 0
+        },
+        "c3b6e0b5-aa50-4422-9b5d-95d0bf2ccb6a": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "layer": 50,
+            "to": "de91a377-b869-4e02-b152-b004e5278d80",
+            "width": 0
+        },
+        "e8860077-9473-4bd1-9a80-f308d81fad31": {
+            "center": "d6721cb3-93cb-474c-abb4-6dc2500e8abf",
+            "from": "de91a377-b869-4e02-b152-b004e5278d80",
+            "layer": 50,
+            "to": "29376dd8-0fc5-4e57-9f9d-eddc61233345",
+            "width": 0
+        }
+    },
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "22e3b4d1-96f7-4c12-958d-e065d22dfad2": {
+            "position": [
+                -2500000,
+                -5000000
+            ]
+        },
+        "235e1f2b-9fe6-42ff-87d0-a1eca75ee20d": {
+            "position": [
+                0,
+                5000000
+            ]
+        },
+        "29376dd8-0fc5-4e57-9f9d-eddc61233345": {
+            "position": [
+                -2375000,
+                4250000
+            ]
+        },
+        "39813940-8d3d-4fa8-b4ac-1d9c35b099ee": {
+            "position": [
+                -2000000,
+                4247500
+            ]
+        },
+        "64718648-03a9-49df-b22d-3cb09f07ad3b": {
+            "position": [
+                2500000,
+                5000000
+            ]
+        },
+        "71230b10-1560-4af4-a436-4bcbfe939ede": {
+            "position": [
+                0,
+                5000000
+            ]
+        },
+        "744b39e0-e6ae-4848-8c6c-3337674dea6f": {
+            "position": [
+                -875000,
+                5000000
+            ]
+        },
+        "798ae81f-1552-4d05-84c6-cfe3aa7e98b8": {
+            "position": [
+                1000000,
+                5000000
+            ]
+        },
+        "7d855948-6b90-4874-9835-2d1bf1a0cc50": {
+            "position": [
+                -2500000,
+                5000000
+            ]
+        },
+        "9a91aefc-0f6d-410e-aece-2e919dbaddac": {
+            "position": [
+                2500000,
+                -5000000
+            ]
+        },
+        "d6721cb3-93cb-474c-abb4-6dc2500e8abf": {
+            "position": [
+                -2000000,
+                4250000
+            ]
+        },
+        "de91a377-b869-4e02-b152-b004e5278d80": {
+            "position": [
+                -1625000,
+                4250000
+            ]
+        }
+    },
+    "lines": {
+        "1c0de6a1-3778-4653-a33a-253cf74f4a73": {
+            "from": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "layer": 20,
+            "to": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "width": 150000
+        },
+        "795887a2-43cc-4b77-ac31-ef30fbbde774": {
+            "from": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "layer": 20,
+            "to": "64718648-03a9-49df-b22d-3cb09f07ad3b",
+            "width": 150000
+        },
+        "cf636dc0-8aee-484e-8f83-46eb98bb982b": {
+            "from": "9a91aefc-0f6d-410e-aece-2e919dbaddac",
+            "layer": 20,
+            "to": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "width": 150000
+        },
+        "d6b0daea-c9e6-4384-b559-2a28102f51f2": {
+            "from": "22e3b4d1-96f7-4c12-958d-e065d22dfad2",
+            "layer": 20,
+            "to": "7d855948-6b90-4874-9835-2d1bf1a0cc50",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {},
+    "name": "DIP8, 7.62 mm lead span 2.54 mm pitch (with socket, DIY silkscreen)",
+    "pads": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "name": "6",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 700000,
+                "pad_diameter": 1300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -1250000
+                ]
+            }
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    1250000
+                ]
+            }
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "name": "5",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    -3750000
+                ]
+            }
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "name": "7",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    1250000
+                ]
+            }
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "name": "8",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 850000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3750000,
+                    3750000
+                ]
+            }
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -3750000
+                ]
+            }
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    3750000
+                ]
+            }
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 750000,
+                "pad_diameter": 1350000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    -1250000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.000mm 10.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "ad9a41f8-f593-4139-8b5f-e5a0b56c83c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d83c2eb8-42e6-4ea6-8947-f46b8ea582c3": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f807ef0c-28dc-4409-9d2d-bffc99c31986": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        2500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5000000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fb99024f-a2b8-4082-91cc-3d32e40db324": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        -5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5250000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        5250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5250000,
+                        -5250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "socket",
+        "th"
+    ],
+    "texts": {
+        "136bedfd-e2be-414a-a81e-5c8501bef791": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4437500
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "d19a9743-3530-4ad4-aaa8-e19dd7cc46d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -4500000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "3e136a32-7f46-4bd9-ab67-abe64c326a12"
+}


### PR DESCRIPTION
Added footprints for PDIP (Plastic Dual-Inline-Packages) for pin counts 6 to 32. The pad and hole sizes are passed on Level B of IPC-2222¹ with the assumption of 0.55mm maximum lead diameter (which fits both my own measurements of various IC legs, precision and non-precision IC-sockets as well the data-sheets of multiple IC-sockets I checked. 

The DIP package is a bit old-school, but is still used widespread in DIY kits and the maker scene, because it is easier to handsolder than SMD devices.

¹ see: [https://www.pcb-3d.com/knowledge-base/pth-dimensions/](https://www.pcb-3d.com/knowledge-base/pth-dimensions/)