### PR TITLE
Add ECS-MPIL0530 SMD power inductors

### DIFF
--- a/packages/passive/magnetics/ECS-MPIL0530/package.json
+++ b/packages/passive/magnetics/ECS-MPIL0530/package.json
@@ -169,12 +169,6 @@
                 -1525000
             ]
         },
-        "252a435f-3bab-4489-a5c0-ce5f036bca01": {
-            "position": [
-                2745000,
-                2590000
-            ]
-        },
         "307b72f8-da59-47ea-9c87-491786294b69": {
             "position": [
                 -3020000,
@@ -185,12 +179,6 @@
             "position": [
                 -3020000,
                 -2865000
-            ]
-        },
-        "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed": {
-            "position": [
-                -2745000,
-                2590000
             ]
         },
         "59bae71b-a215-475b-9918-81ee7d85161c": {
@@ -211,22 +199,10 @@
                 2865000
             ]
         },
-        "676b93ae-0102-4618-9d8b-df0112d3ed4d": {
-            "position": [
-                -2745000,
-                1390000
-            ]
-        },
         "81c9f428-5af8-4f84-8cbc-1c2795795f0e": {
             "position": [
                 3020000,
                 2865000
-            ]
-        },
-        "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee": {
-            "position": [
-                -1545000,
-                2590000
             ]
         },
         "8c20f99d-561a-4411-83e9-090478b6270a": {
@@ -241,18 +217,6 @@
                 -2865000
             ]
         },
-        "bea745e0-7c3d-4db8-9f28-b70497b50e5a": {
-            "position": [
-                2745000,
-                -2590000
-            ]
-        },
-        "ea18cbe6-cc82-4ad3-b22c-e207c4566c58": {
-            "position": [
-                -2745000,
-                -2590000
-            ]
-        },
         "f4736af7-370a-4fc4-a623-8d8095a5db9f": {
             "position": [
                 3020000,
@@ -261,18 +225,6 @@
         }
     },
     "lines": {
-        "02745793-ce73-42dc-991b-0bff33e1417e": {
-            "from": "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed",
-            "layer": 40,
-            "to": "252a435f-3bab-4489-a5c0-ce5f036bca01",
-            "width": 0
-        },
-        "05f7262c-a8ab-45a2-a036-30ef4cac731f": {
-            "from": "252a435f-3bab-4489-a5c0-ce5f036bca01",
-            "layer": 50,
-            "to": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
-            "width": 0
-        },
         "073f5ceb-27a7-4cff-bb4a-97031e4dbdcd": {
             "from": "0175a15d-adcb-4bb9-a853-cc14eb5ddd97",
             "layer": 20,
@@ -285,23 +237,11 @@
             "to": "0bcddb8e-3fa4-42be-8ccc-7f11f2667ee6",
             "width": 150000
         },
-        "319972df-af7a-4392-b4fa-01348a9ae620": {
-            "from": "252a435f-3bab-4489-a5c0-ce5f036bca01",
-            "layer": 40,
-            "to": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
-            "width": 0
-        },
         "3f1e7161-52ee-4d94-a33e-a049e04e4739": {
             "from": "241be2a5-1446-4adf-bc33-7535287ba217",
             "layer": 20,
             "to": "39af041c-add9-429d-9ae5-fd06822f6477",
             "width": 150000
-        },
-        "46c85399-f10b-489b-8ed7-37bd46b87244": {
-            "from": "676b93ae-0102-4618-9d8b-df0112d3ed4d",
-            "layer": 50,
-            "to": "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee",
-            "width": 0
         },
         "56ded5ac-fcbe-44ad-b556-c9aff3922c3a": {
             "from": "ada90ed0-5722-464c-9b47-a33df22b53d4",
@@ -309,47 +249,17 @@
             "to": "59bae71b-a215-475b-9918-81ee7d85161c",
             "width": 150000
         },
-        "7460f722-d387-4900-94a1-d5821ac5c70d": {
-            "from": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
-            "layer": 40,
-            "to": "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed",
-            "width": 0
-        },
-        "77426b72-1fff-484d-bbff-27b2a2c31539": {
-            "from": "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee",
-            "layer": 50,
-            "to": "252a435f-3bab-4489-a5c0-ce5f036bca01",
-            "width": 0
-        },
-        "80eaad9b-99bf-4237-96e1-2965c400489c": {
-            "from": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
-            "layer": 50,
-            "to": "676b93ae-0102-4618-9d8b-df0112d3ed4d",
-            "width": 0
-        },
         "b6f3aff3-e19e-47c8-b1b8-739dab7dda4b": {
             "from": "660b4f5f-42c2-494c-9140-b05283c2d478",
             "layer": 20,
             "to": "8c20f99d-561a-4411-83e9-090478b6270a",
             "width": 150000
         },
-        "d8e54722-4264-4b4f-8604-4e16e4f7246b": {
-            "from": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
-            "layer": 40,
-            "to": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
-            "width": 0
-        },
         "dfc1f5cc-6b48-4ec9-867e-db16d19d7546": {
             "from": "660b4f5f-42c2-494c-9140-b05283c2d478",
             "layer": 20,
             "to": "81c9f428-5af8-4f84-8cbc-1c2795795f0e",
             "width": 150000
-        },
-        "e1baaac3-463c-456b-a365-fb5c8d00f5aa": {
-            "from": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
-            "layer": 50,
-            "to": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
-            "width": 0
         }
     },
     "manufacturer": "ECS",
@@ -447,6 +357,126 @@
                     "type": "line"
                 }
             ]
+        },
+        "561565f8-4912-49dd-9e0a-b7957178eadc": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2745000,
+                        2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2745000,
+                        2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2745000,
+                        -2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2745000,
+                        -2590000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "578ad141-6b7d-4b9a-950a-3570473411c1": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2745000,
+                        1390000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1545000,
+                        2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2745000,
+                        2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2745000,
+                        -2590000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2745000,
+                        -2590000
+                    ],
+                    "type": "line"
+                }
+            ]
         }
     },
     "tags": [
@@ -460,10 +490,10 @@
             "layer": 50,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 32768,
                 "mirror": false,
                 "shift": [
-                    -2745000,
+                    2745000,
                     0
                 ]
             },

--- a/packages/passive/magnetics/ECS-MPIL0530/package.json
+++ b/packages/passive/magnetics/ECS-MPIL0530/package.json
@@ -1,0 +1,493 @@
+{
+    "_imp": {
+        "grid_spacing": 500000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": false
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": false
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {},
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "0175a15d-adcb-4bb9-a853-cc14eb5ddd97": {
+            "position": [
+                3020000,
+                2865000
+            ]
+        },
+        "0bcddb8e-3fa4-42be-8ccc-7f11f2667ee6": {
+            "position": [
+                3020000,
+                -2865000
+            ]
+        },
+        "154ab0d1-9676-4a6d-a94f-dc1eb5aa90f1": {
+            "position": [
+                3020000,
+                1525000
+            ]
+        },
+        "241be2a5-1446-4adf-bc33-7535287ba217": {
+            "position": [
+                -3020000,
+                -1525000
+            ]
+        },
+        "252a435f-3bab-4489-a5c0-ce5f036bca01": {
+            "position": [
+                2745000,
+                2590000
+            ]
+        },
+        "307b72f8-da59-47ea-9c87-491786294b69": {
+            "position": [
+                -3020000,
+                -2865000
+            ]
+        },
+        "39af041c-add9-429d-9ae5-fd06822f6477": {
+            "position": [
+                -3020000,
+                -2865000
+            ]
+        },
+        "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed": {
+            "position": [
+                -2745000,
+                2590000
+            ]
+        },
+        "59bae71b-a215-475b-9918-81ee7d85161c": {
+            "position": [
+                3020000,
+                -2865000
+            ]
+        },
+        "5cf5f98d-3cb3-4509-b3fc-04237f20c862": {
+            "position": [
+                3020000,
+                -2865000
+            ]
+        },
+        "660b4f5f-42c2-494c-9140-b05283c2d478": {
+            "position": [
+                -3020000,
+                2865000
+            ]
+        },
+        "676b93ae-0102-4618-9d8b-df0112d3ed4d": {
+            "position": [
+                -2745000,
+                1390000
+            ]
+        },
+        "81c9f428-5af8-4f84-8cbc-1c2795795f0e": {
+            "position": [
+                3020000,
+                2865000
+            ]
+        },
+        "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee": {
+            "position": [
+                -1545000,
+                2590000
+            ]
+        },
+        "8c20f99d-561a-4411-83e9-090478b6270a": {
+            "position": [
+                -3020000,
+                1525000
+            ]
+        },
+        "ada90ed0-5722-464c-9b47-a33df22b53d4": {
+            "position": [
+                -3020000,
+                -2865000
+            ]
+        },
+        "bea745e0-7c3d-4db8-9f28-b70497b50e5a": {
+            "position": [
+                2745000,
+                -2590000
+            ]
+        },
+        "ea18cbe6-cc82-4ad3-b22c-e207c4566c58": {
+            "position": [
+                -2745000,
+                -2590000
+            ]
+        },
+        "f4736af7-370a-4fc4-a623-8d8095a5db9f": {
+            "position": [
+                3020000,
+                -1525000
+            ]
+        }
+    },
+    "lines": {
+        "02745793-ce73-42dc-991b-0bff33e1417e": {
+            "from": "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed",
+            "layer": 40,
+            "to": "252a435f-3bab-4489-a5c0-ce5f036bca01",
+            "width": 0
+        },
+        "05f7262c-a8ab-45a2-a036-30ef4cac731f": {
+            "from": "252a435f-3bab-4489-a5c0-ce5f036bca01",
+            "layer": 50,
+            "to": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
+            "width": 0
+        },
+        "073f5ceb-27a7-4cff-bb4a-97031e4dbdcd": {
+            "from": "0175a15d-adcb-4bb9-a853-cc14eb5ddd97",
+            "layer": 20,
+            "to": "154ab0d1-9676-4a6d-a94f-dc1eb5aa90f1",
+            "width": 150000
+        },
+        "09e7a825-84f3-49cc-a61e-f4f600d22433": {
+            "from": "f4736af7-370a-4fc4-a623-8d8095a5db9f",
+            "layer": 20,
+            "to": "0bcddb8e-3fa4-42be-8ccc-7f11f2667ee6",
+            "width": 150000
+        },
+        "319972df-af7a-4392-b4fa-01348a9ae620": {
+            "from": "252a435f-3bab-4489-a5c0-ce5f036bca01",
+            "layer": 40,
+            "to": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
+            "width": 0
+        },
+        "3f1e7161-52ee-4d94-a33e-a049e04e4739": {
+            "from": "241be2a5-1446-4adf-bc33-7535287ba217",
+            "layer": 20,
+            "to": "39af041c-add9-429d-9ae5-fd06822f6477",
+            "width": 150000
+        },
+        "46c85399-f10b-489b-8ed7-37bd46b87244": {
+            "from": "676b93ae-0102-4618-9d8b-df0112d3ed4d",
+            "layer": 50,
+            "to": "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee",
+            "width": 0
+        },
+        "56ded5ac-fcbe-44ad-b556-c9aff3922c3a": {
+            "from": "ada90ed0-5722-464c-9b47-a33df22b53d4",
+            "layer": 20,
+            "to": "59bae71b-a215-475b-9918-81ee7d85161c",
+            "width": 150000
+        },
+        "7460f722-d387-4900-94a1-d5821ac5c70d": {
+            "from": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
+            "layer": 40,
+            "to": "46a6fd2a-cb58-46ff-8caf-1f9cd36c24ed",
+            "width": 0
+        },
+        "77426b72-1fff-484d-bbff-27b2a2c31539": {
+            "from": "864d1f8f-815f-4c9b-830f-5edc5cc5d7ee",
+            "layer": 50,
+            "to": "252a435f-3bab-4489-a5c0-ce5f036bca01",
+            "width": 0
+        },
+        "80eaad9b-99bf-4237-96e1-2965c400489c": {
+            "from": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
+            "layer": 50,
+            "to": "676b93ae-0102-4618-9d8b-df0112d3ed4d",
+            "width": 0
+        },
+        "b6f3aff3-e19e-47c8-b1b8-739dab7dda4b": {
+            "from": "660b4f5f-42c2-494c-9140-b05283c2d478",
+            "layer": 20,
+            "to": "8c20f99d-561a-4411-83e9-090478b6270a",
+            "width": 150000
+        },
+        "d8e54722-4264-4b4f-8604-4e16e4f7246b": {
+            "from": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
+            "layer": 40,
+            "to": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
+            "width": 0
+        },
+        "dfc1f5cc-6b48-4ec9-867e-db16d19d7546": {
+            "from": "660b4f5f-42c2-494c-9140-b05283c2d478",
+            "layer": 20,
+            "to": "81c9f428-5af8-4f84-8cbc-1c2795795f0e",
+            "width": 150000
+        },
+        "e1baaac3-463c-456b-a365-fb5c8d00f5aa": {
+            "from": "bea745e0-7c3d-4db8-9f28-b70497b50e5a",
+            "layer": 50,
+            "to": "ea18cbe6-cc82-4ad3-b22c-e207c4566c58",
+            "width": 0
+        }
+    },
+    "manufacturer": "ECS",
+    "models": {},
+    "name": "ECS-MPIL0530",
+    "pads": {
+        "3a78b8f9-cbba-4c44-a343-d6123c4e94d0": {
+            "name": "2",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 2500000,
+                "pad_width": 1800000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2400000,
+                    0
+                ]
+            }
+        },
+        "e245922f-1416-4f4c-a410-d3046611c72d": {
+            "name": "1",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 2500000,
+                "pad_width": 1800000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2400000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "6.600mm 5.180mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "179289e0-6d8c-431c-b829-a7c76e54ddef": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3550000,
+                        -2840000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3550000,
+                        2840000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3550000,
+                        2840000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3550000,
+                        -2840000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "inductor",
+        "passive",
+        "smd"
+    ],
+    "texts": {
+        "80f3de62-7c95-414c-a2a8-3ee59f1a34d5": {
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2745000,
+                    0
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        },
+        "92e4b80a-d3d2-426a-954d-d13ea43bc820": {
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3020000,
+                    3840000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        }
+    },
+    "type": "package",
+    "uuid": "78b1fb28-9253-4d4e-9941-a31728ea366f"
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-1R0MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-1R0MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-1R0MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "353e03b5-345c-41f2-84af-f720e148382f",
+    "value": [
+        false,
+        "1 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-1R5MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-1R5MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-1R5MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "8e568cdb-e2e0-4260-870c-27c4db0d6fd1",
+    "value": [
+        false,
+        "1.5 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-220MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-220MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-220MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "fb1a5e67-9143-49ce-8c43-cc9c199be7f8",
+    "value": [
+        false,
+        "22 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-2R2MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-2R2MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-2R2MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "52dea288-14b0-4fc2-a357-21e00afc7f29",
+    "value": [
+        false,
+        "2.2 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-3R3MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-3R3MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-3R3MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "843fa768-1ddc-4847-910e-47e8183b112c",
+    "value": [
+        false,
+        "3.3 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-4R7MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-4R7MC.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-4R7MC"
+    ],
+    "base": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "datasheet": [
+        true,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        true,
+        "SMD power inductor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "d75d1492-0506-49e3-8524-3ff321867059",
+    "value": [
+        false,
+        "4.7 µH"
+    ]
+}

--- a/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-R68MC.json
+++ b/parts/passive/magnetics/ECS-MPIL0530/ECS-MPIL0530-R68MC.json
@@ -1,0 +1,44 @@
+{
+    "MPN": [
+        false,
+        "ECS-MPIL0530-R68MC"
+    ],
+    "datasheet": [
+        false,
+        "https://www.ecsxtal.com/store/pdf/ECS-MPIL0530-SMD-POWER-INDUCTOR.pdf"
+    ],
+    "description": [
+        false,
+        "SMD power inductor"
+    ],
+    "entity": "1d534e1d-704a-4d44-a6e6-c6106a2827ab",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "ECS"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "78b1fb28-9253-4d4e-9941-a31728ea366f",
+    "pad_map": {
+        "3a78b8f9-cbba-4c44-a343-d6123c4e94d0": {
+            "gate": "48af78e5-730e-44eb-977a-cf188e4fcb39",
+            "pin": "dda0ec99-5d70-4fbe-a8db-897542e7554e"
+        },
+        "e245922f-1416-4f4c-a410-d3046611c72d": {
+            "gate": "48af78e5-730e-44eb-977a-cf188e4fcb39",
+            "pin": "6a44037c-65e2-4876-9359-42890048841d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "inductor",
+        "smd"
+    ],
+    "type": "part",
+    "uuid": "09ab40d2-3ec0-4d51-9395-4fbdf15926e7",
+    "value": [
+        false,
+        "0.68 µH"
+    ]
+}


### PR DESCRIPTION
Two questions in this context:
- Is there any way to make “EU inductor with core” the default symbol? I'm not sure why they are alternatives anyway.
- Should non-polarised components include the pin 1 indication in the assembly layer? Manufacturing-wise it doesn't make much sense, but maybe it's helpful for probing around prototypes or something?