### PR TITLE
Add WS2812B

### DIFF
--- a/entities/opto/WS2812B.json
+++ b/entities/opto/WS2812B.json
@@ -1,0 +1,19 @@
+{
+    "gates": {
+        "79a5fea5-ea4b-47ac-a841-2b62d92ea338": {
+            "name": "",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "2ffde499-4491-445a-b8de-8505dee203a6"
+        }
+    },
+    "manufacturer": "Worldsemi",
+    "name": "WS2812B",
+    "prefix": "D",
+    "tags": [
+        "led",
+        "rgb"
+    ],
+    "type": "entity",
+    "uuid": "a81722b8-6723-40bf-80c2-56d62ee0b3f7"
+}

--- a/entities/opto/WS2812B.json
+++ b/entities/opto/WS2812B.json
@@ -1,7 +1,7 @@
 {
     "gates": {
         "79a5fea5-ea4b-47ac-a841-2b62d92ea338": {
-            "name": "",
+            "name": "Main",
             "suffix": "",
             "swap_group": 0,
             "unit": "2ffde499-4491-445a-b8de-8505dee203a6"

--- a/packages/manufacturer/worldsemi/led/LED_5050_4_pins/package.json
+++ b/packages/manufacturer/worldsemi/led/LED_5050_4_pins/package.json
@@ -1,0 +1,592 @@
+{
+    "_imp": {
+        "grid_spacing": 1000000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 1.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.5,
+                        "r": 0.0
+                    },
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "color": {
+                        "b": 0.25,
+                        "g": 0.5,
+                        "r": 0.25
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "color": {
+                        "b": 0.0,
+                        "g": 0.0,
+                        "r": 1.0
+                    },
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 1.0
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "color": {
+                        "b": 0.8999999761581421,
+                        "g": 0.8999999761581421,
+                        "r": 0.8999999761581421
+                    },
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "30": {
+                    "color": {
+                        "b": 0.800000011920929,
+                        "g": 0.800000011920929,
+                        "r": 0.800000011920929
+                    },
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": false
+                },
+                "50": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "color": {
+                        "b": 0.5,
+                        "g": 0.5,
+                        "r": 0.5
+                    },
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {},
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "junctions": {
+        "013466e3-8da0-40c0-b529-88497c1cfb34": {
+            "position": [
+                2775000,
+                925000
+            ]
+        },
+        "0a5eadef-b2cb-45a3-9809-28f548ecbb68": {
+            "position": [
+                2775000,
+                2775000
+            ]
+        },
+        "1813fd5d-bc62-40e9-ace9-04dc9ec2eed4": {
+            "position": [
+                2775000,
+                -925000
+            ]
+        },
+        "1d191cdc-83e2-477a-9769-7434e679ad4a": {
+            "position": [
+                -2775000,
+                -925000
+            ]
+        },
+        "26a2e8b3-81d3-4095-b900-0fd604e22a40": {
+            "position": [
+                -2775000,
+                2775000
+            ]
+        },
+        "3892db7c-1fc4-4f94-a185-fb67f816a2f2": {
+            "position": [
+                -2775000,
+                -2775000
+            ]
+        },
+        "528f2413-633f-441b-8c5e-b767fd2e4690": {
+            "position": [
+                2775000,
+                2375000
+            ]
+        },
+        "5a8e273e-dbcf-4c07-83e4-0f185799a382": {
+            "position": [
+                -2775000,
+                -2775000
+            ]
+        },
+        "6114aa18-a5f0-4a59-b904-0f71f901f792": {
+            "position": [
+                -2775000,
+                925000
+            ]
+        },
+        "69f2121e-8314-47c0-ba03-53e331bc77cd": {
+            "position": [
+                -2775000,
+                2775000
+            ]
+        },
+        "6dbd8d49-1c11-4df0-821b-01c9532f52cd": {
+            "position": [
+                2775000,
+                -2375000
+            ]
+        },
+        "6dcd88fa-70db-4c13-b1a5-fc94dc85297b": {
+            "position": [
+                -3125000,
+                2375000
+            ]
+        },
+        "b2a276ec-91db-4b27-b144-a607adc352e2": {
+            "position": [
+                -2775000,
+                2375000
+            ]
+        },
+        "c861bc5a-c202-4f81-828a-2a577351f8ed": {
+            "position": [
+                2775000,
+                -2775000
+            ]
+        },
+        "d30e8d2e-b402-492c-8d59-962e6c33af9f": {
+            "position": [
+                2775000,
+                -2775000
+            ]
+        },
+        "d55bbb64-d655-4f41-a5b5-45be04ec92cd": {
+            "position": [
+                -2775000,
+                -2375000
+            ]
+        }
+    },
+    "lines": {
+        "12c6f287-c5d8-424a-9db6-4864bc831f26": {
+            "from": "d55bbb64-d655-4f41-a5b5-45be04ec92cd",
+            "layer": 20,
+            "to": "3892db7c-1fc4-4f94-a185-fb67f816a2f2",
+            "width": 150000
+        },
+        "44095bab-fd6d-4f95-a3e8-c3ae7424f0f1": {
+            "from": "5a8e273e-dbcf-4c07-83e4-0f185799a382",
+            "layer": 20,
+            "to": "d30e8d2e-b402-492c-8d59-962e6c33af9f",
+            "width": 150000
+        },
+        "5ecbb5ef-587e-4e16-a061-f0483488193e": {
+            "from": "0a5eadef-b2cb-45a3-9809-28f548ecbb68",
+            "layer": 20,
+            "to": "528f2413-633f-441b-8c5e-b767fd2e4690",
+            "width": 150000
+        },
+        "68250d42-2f51-4b31-80af-3c97edf6ec6f": {
+            "from": "013466e3-8da0-40c0-b529-88497c1cfb34",
+            "layer": 20,
+            "to": "1813fd5d-bc62-40e9-ace9-04dc9ec2eed4",
+            "width": 150000
+        },
+        "b4d00b4d-4976-4a05-b886-e510d0f48108": {
+            "from": "6114aa18-a5f0-4a59-b904-0f71f901f792",
+            "layer": 20,
+            "to": "1d191cdc-83e2-477a-9769-7434e679ad4a",
+            "width": 150000
+        },
+        "d154be0e-c583-4a6b-a06b-a661cd76aaed": {
+            "from": "b2a276ec-91db-4b27-b144-a607adc352e2",
+            "layer": 20,
+            "to": "6dcd88fa-70db-4c13-b1a5-fc94dc85297b",
+            "width": 150000
+        },
+        "d2337e1f-8309-4b0a-b47e-1431f7f68d98": {
+            "from": "26a2e8b3-81d3-4095-b900-0fd604e22a40",
+            "layer": 20,
+            "to": "b2a276ec-91db-4b27-b144-a607adc352e2",
+            "width": 150000
+        },
+        "ee6e3f03-1965-4335-a4d7-1ab160fd2cf4": {
+            "from": "6dbd8d49-1c11-4df0-821b-01c9532f52cd",
+            "layer": 20,
+            "to": "c861bc5a-c202-4f81-828a-2a577351f8ed",
+            "width": 150000
+        },
+        "f5f617ab-4ac3-4fc7-b70c-2f4f68d8ceef": {
+            "from": "69f2121e-8314-47c0-ba03-53e331bc77cd",
+            "layer": 20,
+            "to": "0a5eadef-b2cb-45a3-9809-28f548ecbb68",
+            "width": 150000
+        }
+    },
+    "manufacturer": "Worldsemi",
+    "models": {},
+    "name": "LED 5050, 4 pins",
+    "pads": {
+        "44b56669-62c8-4eee-b61a-218d4fbb8202": {
+            "name": "4",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 900000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2450000,
+                    1650000
+                ]
+            }
+        },
+        "78c691b6-28f3-4145-95bb-e5436a4e48d8": {
+            "name": "1",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 900000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2450000,
+                    1650000
+                ]
+            }
+        },
+        "7c14e396-0135-463d-ab56-9aa7e40023d2": {
+            "name": "2",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 900000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2450000,
+                    -1650000
+                ]
+            }
+        },
+        "fe43b9d3-696e-4bae-9d64-916b248ddce3": {
+            "name": "3",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 900000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2450000,
+                    -1650000
+                ]
+            }
+        }
+    },
+    "parameter_program": "6.400mm 5.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "3118d10f-b2b8-48e1-9983-81985d50d0fc": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        1300000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1300000,
+                        2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -2500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "cc6e2536-ea57-4e3c-ac2a-abe1b5f6f589": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3450000,
+                        -2750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3450000,
+                        2750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        2750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3450000,
+                        -2750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "ec0c58d8-7770-45cc-ba9b-679bbf2a1da3": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        -2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2500000,
+                        2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        2500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2500000,
+                        -2500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "led",
+        "smd"
+    ],
+    "texts": {
+        "973fce83-ee73-428d-88c0-5ce50f61b2dd": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2500000,
+                    0
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        },
+        "e60b3a1e-11c8-4024-9271-9a9d27bbfa12": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2775000,
+                    3775000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        }
+    },
+    "type": "package",
+    "uuid": "03bd0e4b-df01-45ca-96c7-55071f67f67e"
+}

--- a/parts/opto/led/WS2812B.json
+++ b/parts/opto/led/WS2812B.json
@@ -9,7 +9,7 @@
     ],
     "description": [
         false,
-        "RGB led with integrated controller"
+        "RGB LED with integrated controller"
     ],
     "entity": "a81722b8-6723-40bf-80c2-56d62ee0b3f7",
     "inherit_model": false,

--- a/parts/opto/led/WS2812B.json
+++ b/parts/opto/led/WS2812B.json
@@ -1,0 +1,53 @@
+{
+    "MPN": [
+        false,
+        "WS2812B"
+    ],
+    "datasheet": [
+        false,
+        "http://www.world-semi.com/DownLoadFile/108"
+    ],
+    "description": [
+        false,
+        "RGB led with integrated controller"
+    ],
+    "entity": "a81722b8-6723-40bf-80c2-56d62ee0b3f7",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Worldsemi"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "03bd0e4b-df01-45ca-96c7-55071f67f67e",
+    "pad_map": {
+        "44b56669-62c8-4eee-b61a-218d4fbb8202": {
+            "gate": "79a5fea5-ea4b-47ac-a841-2b62d92ea338",
+            "pin": "d073ad09-bbad-4f53-a2cd-da7dcf254913"
+        },
+        "78c691b6-28f3-4145-95bb-e5436a4e48d8": {
+            "gate": "79a5fea5-ea4b-47ac-a841-2b62d92ea338",
+            "pin": "ea0aa827-e39d-423b-8ed3-f7ba9d780bf2"
+        },
+        "7c14e396-0135-463d-ab56-9aa7e40023d2": {
+            "gate": "79a5fea5-ea4b-47ac-a841-2b62d92ea338",
+            "pin": "03342812-eb97-4332-9a74-e47698ff658d"
+        },
+        "fe43b9d3-696e-4bae-9d64-916b248ddce3": {
+            "gate": "79a5fea5-ea4b-47ac-a841-2b62d92ea338",
+            "pin": "65485741-8197-405c-b3ed-18175fd7cb64"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "led",
+        "rgb",
+        "smd"
+    ],
+    "type": "part",
+    "uuid": "01bd7c48-72cb-42c2-a4da-91f859faae90",
+    "value": [
+        false,
+        "WS2812B"
+    ]
+}

--- a/symbols/opto/leds/WS2812B.json
+++ b/symbols/opto/leds/WS2812B.json
@@ -1,0 +1,353 @@
+{
+    "arcs": {},
+    "junctions": {
+        "004c6338-f817-4ad9-8c83-785cddf9c429": {
+            "position": [
+                625000,
+                1250000
+            ]
+        },
+        "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d": {
+            "position": [
+                1875000,
+                2500000
+            ]
+        },
+        "1497a145-c698-4ef9-880b-e8fb2232e013": {
+            "position": [
+                625000,
+                2500000
+            ]
+        },
+        "19e37374-1bfd-41a7-8bb0-7866e31123e1": {
+            "position": [
+                7500000,
+                6250000
+            ]
+        },
+        "1fe07b87-5400-4198-8791-00cf2957c958": {
+            "position": [
+                1250000,
+                0
+            ]
+        },
+        "4cf6369a-18ae-4f87-83b1-f080f554a8b9": {
+            "position": [
+                -1250000,
+                0
+            ]
+        },
+        "58279b6c-16e5-4496-b134-2f2bb921abac": {
+            "position": [
+                7500000,
+                -6250000
+            ]
+        },
+        "7a81df03-8c5d-459f-9ce8-5324dd4c23c3": {
+            "position": [
+                2500000,
+                0
+            ]
+        },
+        "8c680cbd-5ff5-45a4-bf3b-0367843e09e9": {
+            "position": [
+                -7500000,
+                -6250000
+            ]
+        },
+        "9ea12d10-2806-4ebc-9da2-7be2bfa96c05": {
+            "position": [
+                -1250000,
+                1250000
+            ]
+        },
+        "a8711db2-707b-44a3-b56f-1c772a605c02": {
+            "position": [
+                1250000,
+                2500000
+            ]
+        },
+        "aae03c91-2c7e-49de-9eca-4581f860a09d": {
+            "position": [
+                625000,
+                1875000
+            ]
+        },
+        "b4171d72-3985-4b39-8a8b-812261c87e2d": {
+            "position": [
+                0,
+                2500000
+            ]
+        },
+        "cbd92b1c-0dbb-401d-92a2-43df146e399c": {
+            "position": [
+                -1250000,
+                -1250000
+            ]
+        },
+        "d4d88a7d-cbf0-412c-b492-d91edb87585c": {
+            "position": [
+                1250000,
+                -1250000
+            ]
+        },
+        "d60ecd61-ebee-4f11-8fe2-e9d31925d135": {
+            "position": [
+                -625000,
+                1250000
+            ]
+        },
+        "da4ecc0b-75c5-4619-9cb8-c411c0106465": {
+            "position": [
+                1875000,
+                1875000
+            ]
+        },
+        "e1cce214-b1b3-4630-8cba-bbc9f4eee3e1": {
+            "position": [
+                -2500000,
+                0
+            ]
+        },
+        "ea908eb5-88ec-4c71-85c2-d3047d7bd347": {
+            "position": [
+                1250000,
+                1250000
+            ]
+        },
+        "fda53859-71d1-4cf1-bca7-22f89e426415": {
+            "position": [
+                -7500000,
+                6250000
+            ]
+        }
+    },
+    "lines": {
+        "024e7f8a-90ff-45f0-b035-7ea066e8a99a": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "18a13483-fd67-493d-818d-541358d39fe6": {
+            "from": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "layer": 0,
+            "to": "b4171d72-3985-4b39-8a8b-812261c87e2d",
+            "width": 0
+        },
+        "1c099213-13ab-4e6d-84ea-b8316e1df216": {
+            "from": "e1cce214-b1b3-4630-8cba-bbc9f4eee3e1",
+            "layer": 0,
+            "to": "4cf6369a-18ae-4f87-83b1-f080f554a8b9",
+            "width": 0
+        },
+        "1d5ddb64-f0cc-4bc4-8928-7f8ef310e2a4": {
+            "from": "d60ecd61-ebee-4f11-8fe2-e9d31925d135",
+            "layer": 0,
+            "to": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "width": 0
+        },
+        "225653f8-6512-4be1-8dee-0db7371361dc": {
+            "from": "d4d88a7d-cbf0-412c-b492-d91edb87585c",
+            "layer": 0,
+            "to": "ea908eb5-88ec-4c71-85c2-d3047d7bd347",
+            "width": 0
+        },
+        "4deed3f3-c04b-4dc8-a844-f54c0751a593": {
+            "from": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "layer": 0,
+            "to": "a8711db2-707b-44a3-b56f-1c772a605c02",
+            "width": 0
+        },
+        "4ecf73dc-f570-46de-8ed1-e1df995f8986": {
+            "from": "8c680cbd-5ff5-45a4-bf3b-0367843e09e9",
+            "layer": 0,
+            "to": "fda53859-71d1-4cf1-bca7-22f89e426415",
+            "width": 0
+        },
+        "5a8af0f3-5934-4b83-b7e6-da6c689d6717": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "6dcefb50-dba3-48bc-ab42-6146799dc5d2": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "cbd92b1c-0dbb-401d-92a2-43df146e399c",
+            "width": 0
+        },
+        "6e98c39f-e5a8-4b8f-9357-633b45ed1cba": {
+            "from": "004c6338-f817-4ad9-8c83-785cddf9c429",
+            "layer": 0,
+            "to": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "width": 0
+        },
+        "719b9459-8bf9-4bfb-b1ed-8431331f72d0": {
+            "from": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "layer": 0,
+            "to": "aae03c91-2c7e-49de-9eca-4581f860a09d",
+            "width": 0
+        },
+        "869f42fa-853a-4dac-9100-4a8dcf2024d3": {
+            "from": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "layer": 0,
+            "to": "7a81df03-8c5d-459f-9ce8-5324dd4c23c3",
+            "width": 0
+        },
+        "959a0f88-4797-4e27-b4d4-5dda1f8b649d": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "a70df877-103d-4ba6-b4d1-5313836582e8": {
+            "from": "58279b6c-16e5-4496-b134-2f2bb921abac",
+            "layer": 0,
+            "to": "8c680cbd-5ff5-45a4-bf3b-0367843e09e9",
+            "width": 0
+        },
+        "af6e3ecd-2db0-4bee-8edd-a9900d6146bd": {
+            "from": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "c3ab44fc-c9b8-4307-b5dd-ad4fe6789619": {
+            "from": "fda53859-71d1-4cf1-bca7-22f89e426415",
+            "layer": 0,
+            "to": "19e37374-1bfd-41a7-8bb0-7866e31123e1",
+            "width": 0
+        },
+        "cc594951-be95-4720-95ef-c5a5235a288e": {
+            "from": "19e37374-1bfd-41a7-8bb0-7866e31123e1",
+            "layer": 0,
+            "to": "58279b6c-16e5-4496-b134-2f2bb921abac",
+            "width": 0
+        },
+        "d838230d-8030-4ad0-8262-f4df76970d5d": {
+            "from": "cbd92b1c-0dbb-401d-92a2-43df146e399c",
+            "layer": 0,
+            "to": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "width": 0
+        },
+        "fbfb2694-12c4-4f3e-9a1c-f9dcfe3496d3": {
+            "from": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "layer": 0,
+            "to": "da4ecc0b-75c5-4619-9cb8-c411c0106465",
+            "width": 0
+        }
+    },
+    "name": "WS2812B",
+    "pins": {
+        "03342812-eb97-4332-9a74-e47698ff658d": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                0
+            ]
+        },
+        "65485741-8197-405c-b3ed-18175fd7cb64": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                8750000
+            ]
+        },
+        "d073ad09-bbad-4f53-a2cd-da7dcf254913": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                0
+            ]
+        },
+        "ea0aa827-e39d-423b-8ed3-f7ba9d780bf2": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                0,
+                -8750000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {
+        "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    1250000,
+                    7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        },
+        "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    1250000,
+                    -7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "2ffde499-4491-445a-b8de-8505dee203a6",
+    "uuid": "ba5a81b0-d529-42f9-a7be-3188c38cad8b"
+}

--- a/units/opto/leds/WS2812B.json
+++ b/units/opto/leds/WS2812B.json
@@ -1,0 +1,32 @@
+{
+    "manufacturer": "Worldsemi",
+    "name": "WS2812B",
+    "pins": {
+        "03342812-eb97-4332-9a74-e47698ff658d": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "DI",
+            "swap_group": 0
+        },
+        "65485741-8197-405c-b3ed-18175fd7cb64": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VDD",
+            "swap_group": 0
+        },
+        "d073ad09-bbad-4f53-a2cd-da7dcf254913": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "DO",
+            "swap_group": 0
+        },
+        "ea0aa827-e39d-423b-8ed3-f7ba9d780bf2": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VSS",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "2ffde499-4491-445a-b8de-8505dee203a6"
+}


### PR DESCRIPTION
Based on this [datasheet](http://www.world-semi.com/DownLoadFile/108). I looked around for a 3D model for quite a bit, bit didn't find any with a compatible licence, so there is none included. I took the liberty to change some things in comparison to the datasheet:

* The pin numbering is rotated by 180 degrees. IMHO, it makes more sense that pin 1 is actually the pin with the bevelled corner of the package. This seems to be the convention for all the other LED PLCC footprints I found, too.
* DIN/DOUT have been renamed to DI/DO, so they take less space in the symbol.