### PR TITLE
Added Alfa AS3320 IC

### DIFF
--- a/entities/ic/manufacturer/alfa/as3320.json
+++ b/entities/ic/manufacturer/alfa/as3320.json
@@ -1,0 +1,19 @@
+{
+    "gates": {
+        "2360662f-1f83-477e-a87c-e3d3bd1d1fde": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "f823b98e-0a7e-469c-a330-4f309dd5f04a"
+        }
+    },
+    "manufacturer": "Alfa",
+    "name": "AS3320",
+    "prefix": "Q",
+    "tags": [
+        "filter",
+        "vcf"
+    ],
+    "type": "entity",
+    "uuid": "d4a79d39-9716-4986-a970-c1ac929a8375"
+}

--- a/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
+++ b/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
@@ -1,0 +1,110 @@
+{
+    "MPN": [
+        false,
+        "AS3320 (DIP-18)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.alfarzpp.lv/eng/sc/AS3320.pdf"
+    ],
+    "description": [
+        false,
+        "Voltage Controlled Filter (VCF)"
+    ],
+    "entity": "d4a79d39-9716-4986-a970-c1ac929a8375",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Alfa"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "368eb0f5-ef8e-48c2-9833-0f4b46729eb1",
+    "pad_map": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "0bc03d7e-3c3b-42a5-adff-683d63176c8f"
+        },
+        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "d919053d-bf7d-451f-bbd7-701a31e0d205"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "b761ce4a-7706-4af7-9935-da844f41ee6f"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "91374ff8-45b3-442c-bdfd-1f04a99b4192"
+        },
+        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "f9874c91-597f-4675-9edc-9f0fd868419c"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff"
+        },
+        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "481f8bf9-d5d2-4263-8070-e093cd7cb8a3"
+        },
+        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "3a0514d2-abb0-4237-8c60-39b739aa7d27"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "fc2673ac-9019-42e0-8048-b33131d38af7"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "39982f17-adf2-4577-931f-123e9cea0527"
+        },
+        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "95e2d03d-32d4-4d0d-a269-3a62bae7bec2"
+        },
+        "8c099299-2956-4165-b1d5-51ead05199df": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "df23a7b3-1ff4-404f-b936-6953f84c1c3f"
+        },
+        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "829cb00c-d79c-45de-984f-88262d54b014"
+        },
+        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "dcf92aaf-c6f2-4414-828b-450a952d2a41"
+        },
+        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "6daa9544-0776-4b79-be43-96a95cbcb3e6"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9"
+        },
+        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "9fe5d024-9fcb-417a-9f46-eb1c69f026ec"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "audio",
+        "filter",
+        "ic",
+        "vcf"
+    ],
+    "type": "part",
+    "uuid": "cd394d58-cc31-492e-8d36-d663f6640684",
+    "value": [
+        false,
+        "AS3320"
+    ]
+}

--- a/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
+++ b/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
@@ -19,15 +19,27 @@
         "Alfa"
     ],
     "model": "00000000-0000-0000-0000-000000000000",
-    "package": "368eb0f5-ef8e-48c2-9833-0f4b46729eb1",
+    "package": "2cf1b1cb-e924-4408-9cd2-85d92ebd23ac",
     "pad_map": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "df23a7b3-1ff4-404f-b936-6953f84c1c3f"
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "481f8bf9-d5d2-4263-8070-e093cd7cb8a3"
+        },
         "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "0bc03d7e-3c3b-42a5-adff-683d63176c8f"
         },
-        "33913b3e-eba8-48d1-ba9a-21527a669d13": {
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "d919053d-bf7d-451f-bbd7-701a31e0d205"
+            "pin": "829cb00c-d79c-45de-984f-88262d54b014"
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "6daa9544-0776-4b79-be43-96a95cbcb3e6"
         },
         "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
@@ -37,25 +49,17 @@
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "b761ce4a-7706-4af7-9935-da844f41ee6f"
         },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "95e2d03d-32d4-4d0d-a269-3a62bae7bec2"
+        },
         "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "91374ff8-45b3-442c-bdfd-1f04a99b4192"
         },
-        "6e0539f8-975b-4132-a7f8-e0b610cef1ef": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "f9874c91-597f-4675-9edc-9f0fd868419c"
-        },
         "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff"
-        },
-        "762fc542-d3c4-41a9-9076-b3d3d0054e6e": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "481f8bf9-d5d2-4263-8070-e093cd7cb8a3"
-        },
-        "7bb74859-455a-4b6f-80ac-8d9460d336b0": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "3a0514d2-abb0-4237-8c60-39b739aa7d27"
         },
         "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
@@ -65,33 +69,29 @@
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "39982f17-adf2-4577-931f-123e9cea0527"
         },
-        "8be92db5-9a90-44cf-9402-46de3e8c8fef": {
+        "89289608-e62d-4f74-aafc-7b459044667b": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "95e2d03d-32d4-4d0d-a269-3a62bae7bec2"
+            "pin": "3a0514d2-abb0-4237-8c60-39b739aa7d27"
         },
-        "8c099299-2956-4165-b1d5-51ead05199df": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "df23a7b3-1ff4-404f-b936-6953f84c1c3f"
-        },
-        "b4e6108f-5fda-4b7f-b613-75878d5f8d8b": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "829cb00c-d79c-45de-984f-88262d54b014"
-        },
-        "c0ad1153-6c89-48e9-83d9-0497ef5563cc": {
+        "938b2a3f-ed78-4f91-983e-3ddaf80ae6f9": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "dcf92aaf-c6f2-4414-828b-450a952d2a41"
         },
-        "c8f3cc27-b370-4326-b4fa-23eb3c592055": {
+        "ac5df187-7323-4b04-abab-57ca0f890fc8": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "6daa9544-0776-4b79-be43-96a95cbcb3e6"
+            "pin": "9fe5d024-9fcb-417a-9f46-eb1c69f026ec"
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "d919053d-bf7d-451f-bbd7-701a31e0d205"
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
+            "pin": "f9874c91-597f-4675-9edc-9f0fd868419c"
         },
         "ef232360-f78f-4226-921e-ec90c9f38e0a": {
             "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
             "pin": "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9"
-        },
-        "fbcc730c-a0dc-45ee-adf1-6dbb685256e0": {
-            "gate": "2360662f-1f83-477e-a87c-e3d3bd1d1fde",
-            "pin": "9fe5d024-9fcb-417a-9f46-eb1c69f026ec"
         }
     },
     "parametric": {},

--- a/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
+++ b/parts/ic/manufacturer/alfa/AS3320_DIP-18.json
@@ -1,7 +1,7 @@
 {
     "MPN": [
         false,
-        "AS3320 (DIP-18)"
+        "AS3320"
     ],
     "datasheet": [
         false,

--- a/symbols/ic/manufacturer/alfa/as3320.json
+++ b/symbols/ic/manufacturer/alfa/as3320.json
@@ -3,26 +3,26 @@
     "junctions": {
         "1149f928-eeed-4081-9c81-e4188adeb56a": {
             "position": [
-                -23750000,
-                8750000
+                10000000,
+                25000000
             ]
         },
         "4254ef8b-33d3-4011-8762-a3a684ecf96a": {
             "position": [
-                23750000,
-                8750000
+                10000000,
+                -22500000
             ]
         },
         "64cbf0c1-c066-4823-ae5c-da6d99528ac3": {
             "position": [
-                23750000,
-                -8750000
+                -7500000,
+                -22500000
             ]
         },
         "6a7480d1-4608-4f78-b1c1-da6f36c3d726": {
             "position": [
-                -23750000,
-                -8750000
+                -7500000,
+                25000000
             ]
         }
     },
@@ -64,11 +64,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                5000000,
-                -11250000
+                12500000,
+                -8750000
             ]
         },
         "39982f17-adf2-4577-931f-123e9cea0527": {
@@ -81,11 +81,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                -20000000,
-                -11250000
+                -10000000,
+                21250000
             ]
         },
         "3a0514d2-abb0-4237-8c60-39b739aa7d27": {
@@ -98,11 +98,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                15000000,
-                11250000
+                -10000000,
+                -13750000
             ]
         },
         "481f8bf9-d5d2-4263-8070-e093cd7cb8a3": {
@@ -115,11 +115,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                20000000,
-                -11250000
+                12500000,
+                1250000
             ]
         },
         "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff": {
@@ -132,11 +132,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                15000000,
-                -11250000
+                12500000,
+                6250000
             ]
         },
         "6daa9544-0776-4b79-be43-96a95cbcb3e6": {
@@ -149,11 +149,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                0,
-                11250000
+                12500000,
+                21250000
             ]
         },
         "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9": {
@@ -166,11 +166,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
                 -10000000,
-                -11250000
+                -18750000
             ]
         },
         "829cb00c-d79c-45de-984f-88262d54b014": {
@@ -183,11 +183,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                -5000000,
-                11250000
+                12500000,
+                -13750000
             ]
         },
         "91374ff8-45b3-442c-bdfd-1f04a99b4192": {
@@ -200,11 +200,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                10000000,
-                -11250000
+                12500000,
+                -3750000
             ]
         },
         "95e2d03d-32d4-4d0d-a269-3a62bae7bec2": {
@@ -217,11 +217,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                20000000,
-                11250000
+                12500000,
+                -18750000
             ]
         },
         "9fe5d024-9fcb-417a-9f46-eb1c69f026ec": {
@@ -234,10 +234,10 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                -15000000,
+                -10000000,
                 11250000
             ]
         },
@@ -251,11 +251,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                0,
-                -11250000
+                -10000000,
+                1250000
             ]
         },
         "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1": {
@@ -268,11 +268,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                -15000000,
-                -11250000
+                -10000000,
+                16250000
             ]
         },
         "d919053d-bf7d-451f-bbd7-701a31e0d205": {
@@ -285,11 +285,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                5000000,
-                11250000
+                12500000,
+                16250000
             ]
         },
         "dcf92aaf-c6f2-4414-828b-450a952d2a41": {
@@ -302,11 +302,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                -20000000,
-                11250000
+                -10000000,
+                6250000
             ]
         },
         "df23a7b3-1ff4-404f-b936-6953f84c1c3f": {
@@ -319,10 +319,10 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "right",
             "pad_visible": true,
             "position": [
-                10000000,
+                12500000,
                 11250000
             ]
         },
@@ -336,11 +336,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "up",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
                 -10000000,
-                11250000
+                -8750000
             ]
         },
         "fc2673ac-9019-42e0-8048-b33131d38af7": {
@@ -353,11 +353,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "down",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                -5000000,
-                -11250000
+                -10000000,
+                -3750000
             ]
         }
     },
@@ -373,8 +373,8 @@
                 "angle": 0,
                 "mirror": false,
                 "shift": [
-                    25000000,
-                    -5000000
+                    -7500000,
+                    30000000
                 ]
             },
             "size": 1500000,
@@ -390,8 +390,8 @@
                 "angle": 0,
                 "mirror": false,
                 "shift": [
-                    25000000,
-                    -7500000
+                    -7500000,
+                    27500000
                 ]
             },
             "size": 1500000,
@@ -404,11 +404,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -3750000,
-                    0
+                    1250000,
+                    5000000
                 ]
             },
             "size": 2700000,

--- a/symbols/ic/manufacturer/alfa/as3320.json
+++ b/symbols/ic/manufacturer/alfa/as3320.json
@@ -1,0 +1,405 @@
+{
+    "arcs": {},
+    "junctions": {
+        "1149f928-eeed-4081-9c81-e4188adeb56a": {
+            "position": [
+                -23750000,
+                8750000
+            ]
+        },
+        "4254ef8b-33d3-4011-8762-a3a684ecf96a": {
+            "position": [
+                23750000,
+                8750000
+            ]
+        },
+        "64cbf0c1-c066-4823-ae5c-da6d99528ac3": {
+            "position": [
+                23750000,
+                -8750000
+            ]
+        },
+        "6a7480d1-4608-4f78-b1c1-da6f36c3d726": {
+            "position": [
+                -23750000,
+                -8750000
+            ]
+        }
+    },
+    "lines": {
+        "0b6f867e-d266-4e7b-b2e0-a743c222682e": {
+            "from": "64cbf0c1-c066-4823-ae5c-da6d99528ac3",
+            "layer": 0,
+            "to": "6a7480d1-4608-4f78-b1c1-da6f36c3d726",
+            "width": 0
+        },
+        "8631d493-90a9-4658-99e1-62c1cdd992e7": {
+            "from": "6a7480d1-4608-4f78-b1c1-da6f36c3d726",
+            "layer": 0,
+            "to": "1149f928-eeed-4081-9c81-e4188adeb56a",
+            "width": 0
+        },
+        "962810b6-923a-46f9-abd5-54e2e3cee268": {
+            "from": "1149f928-eeed-4081-9c81-e4188adeb56a",
+            "layer": 0,
+            "to": "4254ef8b-33d3-4011-8762-a3a684ecf96a",
+            "width": 0
+        },
+        "efdd15e1-7dfd-4e1c-9900-98c82815404e": {
+            "from": "4254ef8b-33d3-4011-8762-a3a684ecf96a",
+            "layer": 0,
+            "to": "64cbf0c1-c066-4823-ae5c-da6d99528ac3",
+            "width": 0
+        }
+    },
+    "name": "AS3320",
+    "pins": {
+        "0bc03d7e-3c3b-42a5-adff-683d63176c8f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                5000000,
+                -11250000
+            ]
+        },
+        "39982f17-adf2-4577-931f-123e9cea0527": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -20000000,
+                -11250000
+            ]
+        },
+        "3a0514d2-abb0-4237-8c60-39b739aa7d27": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                11250000
+            ]
+        },
+        "481f8bf9-d5d2-4263-8070-e093cd7cb8a3": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                20000000,
+                -11250000
+            ]
+        },
+        "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                -11250000
+            ]
+        },
+        "6daa9544-0776-4b79-be43-96a95cbcb3e6": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                11250000
+            ]
+        },
+        "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                -11250000
+            ]
+        },
+        "829cb00c-d79c-45de-984f-88262d54b014": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                -5000000,
+                11250000
+            ]
+        },
+        "91374ff8-45b3-442c-bdfd-1f04a99b4192": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                -11250000
+            ]
+        },
+        "95e2d03d-32d4-4d0d-a269-3a62bae7bec2": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                20000000,
+                11250000
+            ]
+        },
+        "9fe5d024-9fcb-417a-9f46-eb1c69f026ec": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                11250000
+            ]
+        },
+        "b761ce4a-7706-4af7-9935-da844f41ee6f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                0,
+                -11250000
+            ]
+        },
+        "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                -11250000
+            ]
+        },
+        "d919053d-bf7d-451f-bbd7-701a31e0d205": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                5000000,
+                11250000
+            ]
+        },
+        "dcf92aaf-c6f2-4414-828b-450a952d2a41": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                -20000000,
+                11250000
+            ]
+        },
+        "df23a7b3-1ff4-404f-b936-6953f84c1c3f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                11250000
+            ]
+        },
+        "f9874c91-597f-4675-9edc-9f0fd868419c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                11250000
+            ]
+        },
+        "fc2673ac-9019-42e0-8048-b33131d38af7": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -5000000,
+                -11250000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {
+        "6184c85b-7d93-4f80-8b50-884dcb6185f7": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    25000000,
+                    -5000000
+                ]
+            },
+            "size": 1500000,
+            "text": "$RD",
+            "width": 0
+        },
+        "7751fb8a-dcaa-4617-b8c2-7dad1e5da5b1": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    25000000,
+                    -7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "f823b98e-0a7e-469c-a330-4f309dd5f04a",
+    "uuid": "59d9fe72-658c-466d-8926-e8e461d3aad3"
+}

--- a/symbols/ic/manufacturer/alfa/as3320.json
+++ b/symbols/ic/manufacturer/alfa/as3320.json
@@ -3,26 +3,26 @@
     "junctions": {
         "1149f928-eeed-4081-9c81-e4188adeb56a": {
             "position": [
-                10000000,
-                25000000
+                -7500000,
+                16250000
             ]
         },
         "4254ef8b-33d3-4011-8762-a3a684ecf96a": {
             "position": [
-                10000000,
-                -22500000
+                -7500000,
+                -16250000
             ]
         },
         "64cbf0c1-c066-4823-ae5c-da6d99528ac3": {
             "position": [
-                -7500000,
-                -22500000
+                7500000,
+                -16250000
             ]
         },
         "6a7480d1-4608-4f78-b1c1-da6f36c3d726": {
             "position": [
-                -7500000,
-                25000000
+                7500000,
+                16250000
             ]
         }
     },
@@ -67,8 +67,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                -8750000
+                10000000,
+                6250000
             ]
         },
         "39982f17-adf2-4577-931f-123e9cea0527": {
@@ -85,7 +85,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                21250000
+                8750000
             ]
         },
         "3a0514d2-abb0-4237-8c60-39b739aa7d27": {
@@ -102,7 +102,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                -13750000
+                -11250000
             ]
         },
         "481f8bf9-d5d2-4263-8070-e093cd7cb8a3": {
@@ -118,8 +118,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                1250000
+                10000000,
+                -6250000
             ]
         },
         "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff": {
@@ -135,8 +135,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                6250000
+                10000000,
+                -3750000
             ]
         },
         "6daa9544-0776-4b79-be43-96a95cbcb3e6": {
@@ -147,13 +147,13 @@
                 "schmitt": false
             },
             "length": 2500000,
-            "name_orientation": "in_line",
+            "name_orientation": "perpendicular",
             "name_visible": true,
-            "orientation": "right",
+            "orientation": "up",
             "pad_visible": true,
             "position": [
-                12500000,
-                21250000
+                0,
+                18750000
             ]
         },
         "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9": {
@@ -164,12 +164,12 @@
                 "schmitt": false
             },
             "length": 2500000,
-            "name_orientation": "in_line",
+            "name_orientation": "perpendicular",
             "name_visible": true,
-            "orientation": "left",
+            "orientation": "down",
             "pad_visible": true,
             "position": [
-                -10000000,
+                -2500000,
                 -18750000
             ]
         },
@@ -186,8 +186,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                -13750000
+                10000000,
+                3750000
             ]
         },
         "91374ff8-45b3-442c-bdfd-1f04a99b4192": {
@@ -203,8 +203,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                -3750000
+                10000000,
+                8750000
             ]
         },
         "95e2d03d-32d4-4d0d-a269-3a62bae7bec2": {
@@ -220,8 +220,8 @@
             "orientation": "right",
             "pad_visible": true,
             "position": [
-                12500000,
-                -18750000
+                10000000,
+                1250000
             ]
         },
         "9fe5d024-9fcb-417a-9f46-eb1c69f026ec": {
@@ -238,7 +238,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                11250000
+                3750000
             ]
         },
         "b761ce4a-7706-4af7-9935-da844f41ee6f": {
@@ -255,7 +255,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                1250000
+                -3750000
             ]
         },
         "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1": {
@@ -272,7 +272,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                16250000
+                6250000
             ]
         },
         "d919053d-bf7d-451f-bbd7-701a31e0d205": {
@@ -283,13 +283,13 @@
                 "schmitt": false
             },
             "length": 2500000,
-            "name_orientation": "in_line",
+            "name_orientation": "perpendicular",
             "name_visible": true,
-            "orientation": "right",
+            "orientation": "down",
             "pad_visible": true,
             "position": [
-                12500000,
-                16250000
+                2500000,
+                -18750000
             ]
         },
         "dcf92aaf-c6f2-4414-828b-450a952d2a41": {
@@ -306,7 +306,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                6250000
+                1250000
             ]
         },
         "df23a7b3-1ff4-404f-b936-6953f84c1c3f": {
@@ -319,11 +319,11 @@
             "length": 2500000,
             "name_orientation": "in_line",
             "name_visible": true,
-            "orientation": "right",
+            "orientation": "left",
             "pad_visible": true,
             "position": [
-                12500000,
-                11250000
+                -10000000,
+                12500000
             ]
         },
         "f9874c91-597f-4675-9edc-9f0fd868419c": {
@@ -357,7 +357,7 @@
             "pad_visible": true,
             "position": [
                 -10000000,
-                -3750000
+                -6250000
             ]
         }
     },
@@ -373,12 +373,12 @@
                 "angle": 0,
                 "mirror": false,
                 "shift": [
-                    -7500000,
-                    30000000
+                    5000000,
+                    17500000
                 ]
             },
             "size": 1500000,
-            "text": "$RD",
+            "text": "$REFDES",
             "width": 0
         },
         "7751fb8a-dcaa-4617-b8c2-7dad1e5da5b1": {
@@ -390,29 +390,12 @@
                 "angle": 0,
                 "mirror": false,
                 "shift": [
-                    -7500000,
-                    27500000
+                    5000000,
+                    -17500000
                 ]
             },
             "size": 1500000,
             "text": "$VALUE",
-            "width": 0
-        },
-        "cea21815-c215-418d-86d1-2513ca74b0fb": {
-            "font": "simplex",
-            "from_smash": false,
-            "layer": 0,
-            "origin": "center",
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    1250000,
-                    5000000
-                ]
-            },
-            "size": 2700000,
-            "text": "VCF",
             "width": 0
         }
     },

--- a/symbols/ic/manufacturer/alfa/as3320.json
+++ b/symbols/ic/manufacturer/alfa/as3320.json
@@ -397,6 +397,23 @@
             "size": 1500000,
             "text": "$VALUE",
             "width": 0
+        },
+        "cea21815-c215-418d-86d1-2513ca74b0fb": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3750000,
+                    0
+                ]
+            },
+            "size": 2700000,
+            "text": "VCF",
+            "width": 0
         }
     },
     "type": "symbol",

--- a/units/manufacturer/alfa/as3320.json
+++ b/units/manufacturer/alfa/as3320.json
@@ -1,0 +1,184 @@
+{
+    "manufacturer": "Alfa",
+    "name": "AS3320",
+    "pins": {
+        "0bc03d7e-3c3b-42a5-adff-683d63176c8f": {
+            "direction": "output",
+            "names": [
+                "Output",
+                "Stage",
+                "2"
+            ],
+            "primary_name": "Out2",
+            "swap_group": 0
+        },
+        "39982f17-adf2-4577-931f-123e9cea0527": {
+            "direction": "input",
+            "names": [
+                "Input",
+                "Stage",
+                "1"
+            ],
+            "primary_name": "IN1",
+            "swap_group": 0
+        },
+        "3a0514d2-abb0-4237-8c60-39b739aa7d27": {
+            "direction": "passive",
+            "names": [
+                "Capacitor",
+                "Stage",
+                "4"
+            ],
+            "primary_name": "Cap4",
+            "swap_group": 0
+        },
+        "481f8bf9-d5d2-4263-8070-e093cd7cb8a3": {
+            "direction": "input",
+            "names": [
+                "Resonance",
+                "Control",
+                "Input"
+            ],
+            "primary_name": "Ires",
+            "swap_group": 0
+        },
+        "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff": {
+            "direction": "input",
+            "names": [
+                "Resonance",
+                "Input"
+            ],
+            "primary_name": "Vres",
+            "swap_group": 0
+        },
+        "6daa9544-0776-4b79-be43-96a95cbcb3e6": {
+            "direction": "power_input",
+            "names": [
+                "Positive",
+                "Power"
+            ],
+            "primary_name": "Vcc",
+            "swap_group": 0
+        },
+        "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9": {
+            "direction": "power_input",
+            "names": [
+                "Ground"
+            ],
+            "primary_name": "GND",
+            "swap_group": 0
+        },
+        "829cb00c-d79c-45de-984f-88262d54b014": {
+            "direction": "output",
+            "names": [
+                "Output",
+                "Stage",
+                "3"
+            ],
+            "primary_name": "Out3",
+            "swap_group": 0
+        },
+        "91374ff8-45b3-442c-bdfd-1f04a99b4192": {
+            "direction": "output",
+            "names": [
+                "Output",
+                "Stage",
+                "1"
+            ],
+            "primary_name": "Out1",
+            "swap_group": 0
+        },
+        "95e2d03d-32d4-4d0d-a269-3a62bae7bec2": {
+            "direction": "output",
+            "names": [
+                "Output",
+                "Stage",
+                "4"
+            ],
+            "primary_name": "Out4",
+            "swap_group": 0
+        },
+        "9fe5d024-9fcb-417a-9f46-eb1c69f026ec": {
+            "direction": "input",
+            "names": [
+                "Input",
+                "Stage",
+                "3"
+            ],
+            "primary_name": "IN3",
+            "swap_group": 0
+        },
+        "b761ce4a-7706-4af7-9935-da844f41ee6f": {
+            "direction": "passive",
+            "names": [
+                "Capacitor",
+                "Stage",
+                "1"
+            ],
+            "primary_name": "Cap1",
+            "swap_group": 0
+        },
+        "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1": {
+            "direction": "input",
+            "names": [
+                "Input",
+                "Stage",
+                "2"
+            ],
+            "primary_name": "IN2",
+            "swap_group": 0
+        },
+        "d919053d-bf7d-451f-bbd7-701a31e0d205": {
+            "direction": "power_input",
+            "names": [
+                "Negative",
+                "Power"
+            ],
+            "primary_name": "Vee",
+            "swap_group": 0
+        },
+        "dcf92aaf-c6f2-4414-828b-450a952d2a41": {
+            "direction": "input",
+            "names": [
+                "Input",
+                "Stage",
+                "4"
+            ],
+            "primary_name": "IN4",
+            "swap_group": 0
+        },
+        "df23a7b3-1ff4-404f-b936-6953f84c1c3f": {
+            "direction": "input",
+            "names": [
+                "Voltage",
+                "Control",
+                "Frequency",
+                "Input"
+            ],
+            "primary_name": "VCFI",
+            "swap_group": 0
+        },
+        "f9874c91-597f-4675-9edc-9f0fd868419c": {
+            "direction": "passive",
+            "names": [
+                "Capacitor",
+                "Stage",
+                "3"
+            ],
+            "primary_name": "Cap3",
+            "swap_group": 0
+        },
+        "fc2673ac-9019-42e0-8048-b33131d38af7": {
+            "direction": "passive",
+            "names": [
+                "Capacitor",
+                "Stage",
+                "2"
+            ],
+            "primary_name": "Cap2",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "f823b98e-0a7e-469c-a330-4f309dd5f04a"
+}

--- a/units/manufacturer/alfa/as3320.json
+++ b/units/manufacturer/alfa/as3320.json
@@ -4,31 +4,19 @@
     "pins": {
         "0bc03d7e-3c3b-42a5-adff-683d63176c8f": {
             "direction": "output",
-            "names": [
-                "Output",
-                "Stage",
-                "2"
-            ],
+            "names": [],
             "primary_name": "Out2",
             "swap_group": 0
         },
         "39982f17-adf2-4577-931f-123e9cea0527": {
             "direction": "input",
-            "names": [
-                "Input",
-                "Stage",
-                "1"
-            ],
+            "names": [],
             "primary_name": "IN1",
             "swap_group": 0
         },
         "3a0514d2-abb0-4237-8c60-39b739aa7d27": {
             "direction": "passive",
-            "names": [
-                "Capacitor",
-                "Stage",
-                "4"
-            ],
+            "names": [],
             "primary_name": "Cap4",
             "swap_group": 0
         },
@@ -44,10 +32,7 @@
         },
         "593ce7ce-fc15-4cbb-9fdb-8f5c4fe65eff": {
             "direction": "input",
-            "names": [
-                "Resonance",
-                "Input"
-            ],
+            "names": [],
             "primary_name": "Vres",
             "swap_group": 0
         },
@@ -62,69 +47,43 @@
         },
         "7cc6326a-2e7a-4a6f-8050-e6a28bcbe6f9": {
             "direction": "power_input",
-            "names": [
-                "Ground"
-            ],
+            "names": [],
             "primary_name": "GND",
             "swap_group": 0
         },
         "829cb00c-d79c-45de-984f-88262d54b014": {
             "direction": "output",
-            "names": [
-                "Output",
-                "Stage",
-                "3"
-            ],
+            "names": [],
             "primary_name": "Out3",
             "swap_group": 0
         },
         "91374ff8-45b3-442c-bdfd-1f04a99b4192": {
             "direction": "output",
-            "names": [
-                "Output",
-                "Stage",
-                "1"
-            ],
+            "names": [],
             "primary_name": "Out1",
             "swap_group": 0
         },
         "95e2d03d-32d4-4d0d-a269-3a62bae7bec2": {
             "direction": "output",
-            "names": [
-                "Output",
-                "Stage",
-                "4"
-            ],
+            "names": [],
             "primary_name": "Out4",
             "swap_group": 0
         },
         "9fe5d024-9fcb-417a-9f46-eb1c69f026ec": {
             "direction": "input",
-            "names": [
-                "Input",
-                "Stage",
-                "3"
-            ],
+            "names": [],
             "primary_name": "IN3",
             "swap_group": 0
         },
         "b761ce4a-7706-4af7-9935-da844f41ee6f": {
             "direction": "passive",
-            "names": [
-                "Capacitor",
-                "Stage",
-                "1"
-            ],
+            "names": [],
             "primary_name": "Cap1",
             "swap_group": 0
         },
         "d318e0d2-2e95-4d6d-9c43-f4a66ddd72e1": {
             "direction": "input",
-            "names": [
-                "Input",
-                "Stage",
-                "2"
-            ],
+            "names": [],
             "primary_name": "IN2",
             "swap_group": 0
         },
@@ -139,11 +98,7 @@
         },
         "dcf92aaf-c6f2-4414-828b-450a952d2a41": {
             "direction": "input",
-            "names": [
-                "Input",
-                "Stage",
-                "4"
-            ],
+            "names": [],
             "primary_name": "IN4",
             "swap_group": 0
         },
@@ -160,21 +115,13 @@
         },
         "f9874c91-597f-4675-9edc-9f0fd868419c": {
             "direction": "passive",
-            "names": [
-                "Capacitor",
-                "Stage",
-                "3"
-            ],
+            "names": [],
             "primary_name": "Cap3",
             "swap_group": 0
         },
         "fc2673ac-9019-42e0-8048-b33131d38af7": {
             "direction": "passive",
-            "names": [
-                "Capacitor",
-                "Stage",
-                "2"
-            ],
+            "names": [],
             "primary_name": "Cap2",
             "swap_group": 0
         }

--- a/units/manufacturer/alfa/as3320.json
+++ b/units/manufacturer/alfa/as3320.json
@@ -22,11 +22,7 @@
         },
         "481f8bf9-d5d2-4263-8070-e093cd7cb8a3": {
             "direction": "input",
-            "names": [
-                "Resonance",
-                "Control",
-                "Input"
-            ],
+            "names": [],
             "primary_name": "Ires",
             "swap_group": 0
         },
@@ -38,10 +34,7 @@
         },
         "6daa9544-0776-4b79-be43-96a95cbcb3e6": {
             "direction": "power_input",
-            "names": [
-                "Positive",
-                "Power"
-            ],
+            "names": [],
             "primary_name": "Vcc",
             "swap_group": 0
         },
@@ -89,10 +82,7 @@
         },
         "d919053d-bf7d-451f-bbd7-701a31e0d205": {
             "direction": "power_input",
-            "names": [
-                "Negative",
-                "Power"
-            ],
+            "names": [],
             "primary_name": "Vee",
             "swap_group": 0
         },
@@ -104,12 +94,7 @@
         },
         "df23a7b3-1ff4-404f-b936-6953f84c1c3f": {
             "direction": "input",
-            "names": [
-                "Voltage",
-                "Control",
-                "Frequency",
-                "Input"
-            ],
+            "names": [],
             "primary_name": "VCFI",
             "swap_group": 0
         },


### PR DESCRIPTION
This is a VCF (Voltage controlled filter) IC by the lithuanian manufacturer ALFA. 
Datasheet is here: http://www.alfarzpp.lv/eng/sc/AS3320.pdf

The AS3320 is a replacement for the out of production CEM3320 which is used in many analog synthesizers.

Feel free to deny this because it is a little oddball.