### PR TITLE
Added LME49720 Dual Opamps

### DIFF
--- a/parts/ic/opamp/LME49720MAX.json
+++ b/parts/ic/opamp/LME49720MAX.json
@@ -1,0 +1,70 @@
+{
+    "MPN": [
+        false,
+        "LME49720MAX"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/lme49720.pdf"
+    ],
+    "description": [
+        false,
+        "Dual Opamp (High Fidelity Audio)"
+    ],
+    "entity": "1bd59d9c-c9e4-40f0-b6b5-8dac58c14df4",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "audio",
+        "dual",
+        "ic",
+        "opamp"
+    ],
+    "type": "part",
+    "uuid": "efc6f9ff-742d-47c0-a365-566d9681b772",
+    "value": [
+        false,
+        "LME49720"
+    ]
+}

--- a/parts/ic/opamp/LME49720NA.json
+++ b/parts/ic/opamp/LME49720NA.json
@@ -1,0 +1,70 @@
+{
+    "MPN": [
+        false,
+        "LME49720NA"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/lme49720.pdf"
+    ],
+    "description": [
+        false,
+        "Dual Opamp (High Fidelity Audio)"
+    ],
+    "entity": "1bd59d9c-c9e4-40f0-b6b5-8dac58c14df4",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "d39137d0-f433-40ab-872c-263c701420b0",
+    "pad_map": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "audio",
+        "dual",
+        "ic",
+        "opamp"
+    ],
+    "type": "part",
+    "uuid": "64ff0fa9-b2d4-4dbb-b3cf-a215b9bc9f01",
+    "value": [
+        false,
+        "LME49720"
+    ]
+}


### PR DESCRIPTION
Not much inheritence going on here, there are only two parts with two MPNs. Datasheet is here: http://www.ti.com/lit/ds/symlink/lme49720.pdf