### PR TITLE
Add licence based on KiCad's CC-BY-SA exception

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+# Horizon Pool License
+
+The Horizon pool is licensed under the [Creative Commons CC-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/legalcode), with the following exception:
+
+---------
+
+_To the extent that the creation of electronic designs that use 'Licensed Material' can be considered to be 'Adapted Material', then the copyright holder waives article 3 of the license with respect to these designs and any generated files which use data provided as part of the 'Licensed Material'._
+
+---------
+
+## What does this mean?
+
+The Horizon pool is licensed in such a way to ensure free use of pool data, such as schematic symbols, PCB footprints and 3D models, for commercial, closed, and non-commercial projects without restriction. Horizon does not wish to exert any control over designs produced using the pool, or force users to reveal proprietary information contained in their designs. Neither do we wish to force users to attribute the Horizon pool _within their design_.
+
+Use of the pool in a project does not (by itself) require that the design or any files generated from the design are licensed under the CC-BY-SA 4.0 License. You are free to use the pool in your own projects without the obligation to share your project files under this or any other license agreement.
+
+However, if you wish to redistribute the Horizon pool, or parts thereof (including in modified form) as a collection then the exception above does not apply. Redistributed pools must be shared under the same license agreement. Under these circumstances, the pool must also retain attribution information, including the license documents which are distributed with the pool files.
+
+## Warranty
+
+The Horizon pool is provided in the hope that it will be useful, but it is provided without warranty of any kind, express or implied.
+
+The Horizon pool is compiled by the Horizon community - if you find an error in the library data, please help the community and contribute a fix!

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@ This is the pool for horizon, see https://github.com/carrotIndustries/horizon on
 Some data has been imported from https://github.com/octopart/CPL-Data/
 3D Models are from https://github.com/KiCad/kicad-packages3D/
 
-This repo is licensed as CC BY-SA 4.0 unless noted
+## Licensing
+
+Refer to the LICENSE.md file


### PR DESCRIPTION
Based on http://kicad-pcb.org/libraries/license/, as discussed here: https://github.com/carrotIndustries/horizon-pool/issues/80

[Rendered view](https://github.com/fruchti/horizon-pool/blob/licence-update/LICENSE.md)

To be able to merge, @carrotIndustries and @atoav as authors of parts of the pool would also have to agree on these new terms, and ideally also @m3mory and @greenscreenflicker as authors of currently open PRs. Please also make sure that any third-party content included in your contributions are compatible with this licence.

Suggestions for improvement are welcome!