### PR TITLE
Added OPAx197 by TI

### DIFF
--- a/parts/ic/opamp/opax197/OPA197IDBVR.json
+++ b/parts/ic/opamp/opax197/OPA197IDBVR.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA197IDBVR"
+    ],
+    "base": "c63bcd60-bb06-46d5-8541-2880c5a3a683",
+    "datasheet": [
+        true,
+        ""
+    ],
+    "description": [
+        true,
+        "Single Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "inherit_model": true,
+    "inherit_tags": false,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "eb54e7ca-dcad-4e09-bd45-d2e32cddaa2a",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "4a60da0e-c2da-4fb4-8d6e-a67b42dbd833",
+    "value": [
+        true,
+        "OPA197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA197IDBVT.json
+++ b/parts/ic/opamp/opax197/OPA197IDBVT.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA197IDBVT"
+    ],
+    "base": "c63bcd60-bb06-46d5-8541-2880c5a3a683",
+    "datasheet": [
+        true,
+        ""
+    ],
+    "description": [
+        true,
+        "Single Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "eb54e7ca-dcad-4e09-bd45-d2e32cddaa2a",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "c2ed5e95-8e0b-48eb-8048-9dadb993b973",
+    "value": [
+        true,
+        "OPA197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA197_base_SOT.json
+++ b/parts/ic/opamp/opax197/OPA197_base_SOT.json
@@ -1,0 +1,59 @@
+{
+    "MPN": [
+        false,
+        "OPA197 (Base Part, SOT)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        false,
+        "Single Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "entity": "add81fb1-566d-4170-868c-264e91f04788",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "eb54e7ca-dcad-4e09-bd45-d2e32cddaa2a",
+    "package": "70c65846-2ee7-4d11-9d38-fe0fa84dc963",
+    "pad_map": {
+        "531c3759-a1b6-40c6-9474-5554dc94bcec": {
+            "gate": "bd7eb247-f40f-48a8-9689-12222ddb433e",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "9fe9b6c3-f887-4523-976a-6aa050235658": {
+            "gate": "18256178-4af0-466a-bc77-60b2a173da56",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "bb9bbbd8-9aa2-49aa-98fd-b508ded56028": {
+            "gate": "18256178-4af0-466a-bc77-60b2a173da56",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "be802fd1-5220-4258-a11f-c1529e6187e0": {
+            "gate": "bd7eb247-f40f-48a8-9689-12222ddb433e",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "f827f54d-8a25-45ce-a5c6-aa1cdc05418a": {
+            "gate": "18256178-4af0-466a-bc77-60b2a173da56",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "ic",
+        "opamp",
+        "rail-to-rail",
+        "single",
+        "sot-23-5"
+    ],
+    "type": "part",
+    "uuid": "c63bcd60-bb06-46d5-8541-2880c5a3a683",
+    "value": [
+        false,
+        "OPA197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA2197ID.json
+++ b/parts/ic/opamp/opax197/OPA2197ID.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA2197ID"
+    ],
+    "base": "aaa66168-c50c-4590-9590-10dbe6d4d32e",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "Dual Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "1083cd42-a3f3-4b63-9967-8fc4daf83a49",
+    "value": [
+        true,
+        "OPA2197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA2197IDR.json
+++ b/parts/ic/opamp/opax197/OPA2197IDR.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA2197IDR"
+    ],
+    "base": "aaa66168-c50c-4590-9590-10dbe6d4d32e",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "Dual Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "1811f06b-d66a-46b8-acc2-90fa02202a93",
+    "value": [
+        true,
+        "OPA2197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA2197_base_soic.json
+++ b/parts/ic/opamp/opax197/OPA2197_base_soic.json
@@ -1,0 +1,71 @@
+{
+    "MPN": [
+        false,
+        "OPA2197 (Base Part, SOIC)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        false,
+        "Dual Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "entity": "1bd59d9c-c9e4-40f0-b6b5-8dac58c14df4",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "050413f6-8890-434c-a3bd-9e7c2976f249",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "0843fb2d-76d6-40b2-b494-1556b278f7ea",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "55742f29-c933-4db8-a50b-b152d5a0436b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "dual",
+        "ic",
+        "opamp",
+        "rail-to-rail",
+        "soic-8"
+    ],
+    "type": "part",
+    "uuid": "aaa66168-c50c-4590-9590-10dbe6d4d32e",
+    "value": [
+        false,
+        "OPA2197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197ID.json
+++ b/parts/ic/opamp/opax197/OPA4197ID.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA4197ID"
+    ],
+    "base": "8de87d1c-5e73-4c6d-8e50-00ac518740ce",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage, Opamp"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "76df7da4-e151-4656-bbc0-d139da67a386",
+    "value": [
+        true,
+        "OPA4197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197IDR.json
+++ b/parts/ic/opamp/opax197/OPA4197IDR.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA4197IDR"
+    ],
+    "base": "8de87d1c-5e73-4c6d-8e50-00ac518740ce",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage, Opamp"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "d5afe78b-a390-4b31-948c-ee3ae55f2926",
+    "value": [
+        true,
+        "OPA4197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197IPW.json
+++ b/parts/ic/opamp/opax197/OPA4197IPW.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA4197IPW"
+    ],
+    "base": "5a4a57ca-6d79-48af-87cb-85379fcf58c1",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage, Opamp"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "06a3b86c-812d-4eb4-adb1-38f7d1c64c42",
+    "value": [
+        true,
+        "OPA4197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197IPWR.json
+++ b/parts/ic/opamp/opax197/OPA4197IPWR.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "OPA4197IPWR"
+    ],
+    "base": "5a4a57ca-6d79-48af-87cb-85379fcf58c1",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        true,
+        "36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage, Opamp"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "4f888128-7ca5-4a22-91df-0bea15bcf632",
+    "value": [
+        true,
+        "OPA4197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197_base-tssop.json
+++ b/parts/ic/opamp/opax197/OPA4197_base-tssop.json
@@ -1,0 +1,95 @@
+{
+    "MPN": [
+        false,
+        "OPA4197 (Base Part, TSSOP)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        false,
+        "Quad Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "entity": "32e151db-ed62-449a-a77a-ad11893d3242",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "12001aad-23c9-46d2-bfdb-75ffd2479776",
+    "pad_map": {
+        "261fe7ff-1e20-45bc-b96f-0733c16960c4": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "427439e3-355e-4c65-a502-338cba5d0f4b": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "46ab3d42-b140-4167-939f-00bebcccfc22": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "48201ebb-e791-4c91-9bdb-fc069831ade8": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "5ea90398-774b-43ec-bd14-db28ef507b64": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "64731022-0d14-4c0a-996c-3eed9f417c00": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "6e7efadb-0a82-4a26-8965-513d6ff56219": {
+            "gate": "e5455ad7-a387-4331-b93d-8bbe00595352",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "af643901-6c38-4b1b-b30c-371212d093f7": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "b37a46a0-e07e-45ef-87df-bfcbf5f5bf8e": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "bf768b4b-3c62-4f52-ac68-910ef1896730": {
+            "gate": "e5455ad7-a387-4331-b93d-8bbe00595352",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "e63a42e9-c280-4bc3-bf38-968baa5264c1": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "e7483de8-0fee-46dc-a2d6-76e13d0a4a35": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "ea132ec2-ccad-48a6-8121-3aab161d5867": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "f0ed5f62-ebda-4736-9d7e-6894f8fb8421": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "ic",
+        "opamp",
+        "quad",
+        "rail-to-rail",
+        "tssop-14"
+    ],
+    "type": "part",
+    "uuid": "5a4a57ca-6d79-48af-87cb-85379fcf58c1",
+    "value": [
+        false,
+        "OPA4197"
+    ]
+}

--- a/parts/ic/opamp/opax197/OPA4197_base_soic.json
+++ b/parts/ic/opamp/opax197/OPA4197_base_soic.json
@@ -1,0 +1,95 @@
+{
+    "MPN": [
+        false,
+        "OPA4197 (Base Part, SOIC)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/opa4197.pdf"
+    ],
+    "description": [
+        false,
+        "Quad Opamp, 36-V, Precision, Rail-to-Rail Input/Output, Low Offset Voltage"
+    ],
+    "entity": "32e151db-ed62-449a-a77a-ad11893d3242",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "14aeb235-3edc-4327-9a25-7de5a4bd6808",
+    "pad_map": {
+        "150ac7fa-7f46-49f2-ab10-8c0f447d0bd4": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "gate": "e5455ad7-a387-4331-b93d-8bbe00595352",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "71284ebf-b339-4f0d-bd5f-765d1eb04896": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "ddc6b3bf-ee7c-4943-a670-4243439957b3"
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "gate": "e5455ad7-a387-4331-b93d-8bbe00595352",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "gate": "16390091-2a6f-4fa6-ba9f-902a69059253",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "gate": "6f55fc51-82a9-4447-a3f0-3bb5593aa34e",
+            "pin": "d9299dc2-67ea-41ca-835e-6a4701093f93"
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "gate": "c9bcb64f-01a2-4980-a354-c6f5124eecd4",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "gate": "5aa5485b-021e-4491-8f53-b8fc42d4fbf2",
+            "pin": "c04e9a4e-64ef-4914-bf4b-c1148575ad69"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "ic",
+        "opamp",
+        "quad",
+        "rail-to-rail",
+        "soic-14"
+    ],
+    "type": "part",
+    "uuid": "8de87d1c-5e73-4c6d-8e50-00ac518740ce",
+    "value": [
+        false,
+        "OPA4197"
+    ]
+}


### PR DESCRIPTION
I added the OPAx197 series by TI as outlined in [this datasheet](http://www.ti.com/lit/ds/symlink/opa4197.pdf).

I left the VSSOP variants out, because I was lazy. If anybody has a package for that, feel free to add.